### PR TITLE
[Translation] Improve translation extraction

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
@@ -28,6 +28,7 @@ use Symfony\Component\Translation\Extractor\ChainExtractor;
 use Symfony\Component\Translation\Extractor\ExtractorInterface;
 use Symfony\Component\Translation\Extractor\PhpAstExtractor;
 use Symfony\Component\Translation\Extractor\Visitor\ConstraintVisitor;
+use Symfony\Component\Translation\Extractor\Visitor\FormTypeVisitor;
 use Symfony\Component\Translation\Extractor\Visitor\TranslatableMessageVisitor;
 use Symfony\Component\Translation\Extractor\Visitor\TransMethodVisitor;
 use Symfony\Component\Translation\Formatter\MessageFormatter;
@@ -162,6 +163,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('translation.extractor.visitor')
 
         ->set('translation.extractor.visitor.constraint', ConstraintVisitor::class)
+            ->tag('translation.extractor.visitor')
+
+        ->set('translation.extractor.visitor.form_type', FormTypeVisitor::class)
             ->tag('translation.extractor.visitor')
 
         ->set('translation.reader', TranslationReader::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
@@ -27,6 +27,7 @@ use Symfony\Component\Translation\Dumper\YamlFileDumper;
 use Symfony\Component\Translation\Extractor\ChainExtractor;
 use Symfony\Component\Translation\Extractor\ExtractorInterface;
 use Symfony\Component\Translation\Extractor\PhpAstExtractor;
+use Symfony\Component\Translation\Extractor\Visitor\BackedEnumVisitor;
 use Symfony\Component\Translation\Extractor\Visitor\ConstraintVisitor;
 use Symfony\Component\Translation\Extractor\Visitor\FormTypeVisitor;
 use Symfony\Component\Translation\Extractor\Visitor\TranslatableMessageVisitor;
@@ -166,6 +167,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('translation.extractor.visitor')
 
         ->set('translation.extractor.visitor.form_type', FormTypeVisitor::class)
+            ->tag('translation.extractor.visitor')
+
+        ->set('translation.extractor.visitor.backed_enum', BackedEnumVisitor::class)
             ->tag('translation.extractor.visitor')
 
         ->set('translation.reader', TranslationReader::class)

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
@@ -24,6 +24,13 @@ class TranslatorPass implements CompilerPassInterface
             return;
         }
 
+        $this->processLoadersAndReaders($container);
+        $this->processExtractorConstraintVisitor($container);
+        $this->processTwigPaths($container);
+    }
+
+    private function processLoadersAndReaders(ContainerBuilder $container): void
+    {
         $loaders = [];
         $loaderRefs = [];
         foreach ($container->findTaggedServiceIds('translation.loader', true) as $id => $attributes) {
@@ -48,29 +55,38 @@ class TranslatorPass implements CompilerPassInterface
             ->replaceArgument(0, ServiceLocatorTagPass::register($container, $loaderRefs))
             ->replaceArgument(3, $loaders)
         ;
+    }
 
-        if ($container->hasDefinition('validator') && $container->hasDefinition('translation.extractor.visitor.constraint')) {
-            $constraintVisitorDefinition = $container->getDefinition('translation.extractor.visitor.constraint');
-            $constraintClassNames = [];
-
-            foreach ($container->getDefinitions() as $definition) {
-                if (!$definition->hasTag('validator.constraint_validator')) {
-                    continue;
-                }
-                // Resolve constraint validator FQCN even if defined as %foo.validator.class% parameter
-                $className = $container->getParameterBag()->resolveValue($definition->getClass());
-                // Extraction of the constraint class name from the Constraint Validator FQCN
-                $constraintClassNames[] = str_replace('Validator', '', substr(strrchr($className, '\\'), 1));
-            }
-
-            $constraintVisitorDefinition->setArgument(0, $constraintClassNames);
+    private function processExtractorConstraintVisitor(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('validator') || !$container->hasDefinition('translation.extractor.visitor.constraint')) {
+            return;
         }
 
+        $constraintVisitorDefinition = $container->getDefinition('translation.extractor.visitor.constraint');
+        $constraintClassNames = [];
+
+        foreach ($container->getDefinitions() as $definition) {
+            if (!$definition->hasTag('validator.constraint_validator')) {
+                continue;
+            }
+            // Resolve constraint validator FQCN even if defined as %foo.validator.class% parameter
+            $className = $container->getParameterBag()->resolveValue($definition->getClass());
+            // Extraction of the constraint class name from the Constraint Validator FQCN
+            $constraintClassNames[] = str_replace('Validator', '', substr(strrchr($className, '\\'), 1));
+        }
+
+        $constraintVisitorDefinition->setArgument(0, $constraintClassNames);
+    }
+
+    private function processTwigPaths(ContainerBuilder $container): void
+    {
         if (!$container->hasParameter('twig.default_path')) {
             return;
         }
 
         $paths = array_keys($container->getDefinition('twig.template_iterator')->getArgument(1));
+
         if ($container->hasDefinition('console.command.translation_debug')) {
             $definition = $container->getDefinition('console.command.translation_debug');
             $definition->replaceArgument(4, $container->getParameter('twig.default_path'));
@@ -79,6 +95,7 @@ class TranslatorPass implements CompilerPassInterface
                 $definition->replaceArgument(6, $paths);
             }
         }
+
         if ($container->hasDefinition('console.command.translation_extract')) {
             $definition = $container->getDefinition('console.command.translation_extract');
             $definition->replaceArgument(5, $container->getParameter('twig.default_path'));

--- a/src/Symfony/Component/Translation/Extractor/PhpAstExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpAstExtractor.php
@@ -66,11 +66,19 @@ final class PhpAstExtractor extends AbstractFileExtractor implements ExtractorIn
         $this->prefix = $prefix;
     }
 
-    protected function canBeExtracted(string $file): bool
+    public function canBeExtracted(string $file): bool
     {
+        $regex = $this->toRegex([
+            't(',
+            '->trans(',
+            'TranslatableMessage',
+            'Symfony\Component\Validator\Constraints',
+            'Symfony\Component\Form\AbstractType',
+        ]);
+
         return 'php' === pathinfo($file, \PATHINFO_EXTENSION)
             && $this->isFile($file)
-            && preg_match('/\bt\(|->trans\(|TranslatableMessage|Symfony\\\\Component\\\\Validator\\\\Constraints|Symfony\\\\Component\\\\Form\\\\AbstractType/i', file_get_contents($file));
+            && preg_match($regex, file_get_contents($file));
     }
 
     protected function extractFromDirectory(array|string $resource): iterable|Finder
@@ -80,5 +88,19 @@ final class PhpAstExtractor extends AbstractFileExtractor implements ExtractorIn
         }
 
         return (new Finder())->files()->name('*.php')->in($resource);
+    }
+
+    /**
+     * @param array<int, string> $find
+     */
+    protected function toRegex(array $find): string
+    {
+        // In the regex '\\\\' matches the character \
+        $find = array_map(fn (string $current): string => str_replace('\\', '\\\\', $current), $find);
+
+        // In the regex '\(' matches the character (
+        $find = array_map(fn (string $current): string => str_replace('(', '\(', $current), $find);
+
+        return '/\b'.implode('|', $find).'/i';
     }
 }

--- a/src/Symfony/Component/Translation/Extractor/PhpAstExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpAstExtractor.php
@@ -70,7 +70,7 @@ final class PhpAstExtractor extends AbstractFileExtractor implements ExtractorIn
     {
         return 'php' === pathinfo($file, \PATHINFO_EXTENSION)
             && $this->isFile($file)
-            && preg_match('/\bt\(|->trans\(|TranslatableMessage|Symfony\\\\Component\\\\Validator\\\\Constraints/i', file_get_contents($file));
+            && preg_match('/\bt\(|->trans\(|TranslatableMessage|Symfony\\\\Component\\\\Validator\\\\Constraints|Symfony\\\\Component\\\\Form\\\\AbstractType/i', file_get_contents($file));
     }
 
     protected function extractFromDirectory(array|string $resource): iterable|Finder

--- a/src/Symfony/Component/Translation/Extractor/Visitor/AbstractVisitor.php
+++ b/src/Symfony/Component/Translation/Extractor/Visitor/AbstractVisitor.php
@@ -81,7 +81,7 @@ abstract class AbstractVisitor
         return \PHP_INT_MAX;
     }
 
-    private function getStringNamedArguments(Node\Expr\CallLike|Node\Attribute $node, ?string $argumentName = null, bool $isArgumentNamePattern = false): array
+    protected function getStringNamedArguments(Node\Expr\CallLike|Node\Attribute $node, ?string $argumentName = null, bool $isArgumentNamePattern = false): array
     {
         $args = $node instanceof Node\Expr\CallLike ? $node->getArgs() : $node->args;
         $argumentValues = [];
@@ -97,22 +97,14 @@ abstract class AbstractVisitor
         return array_filter($argumentValues);
     }
 
-    private function getStringValue(Node $node): ?string
+    protected function getStringValue(Node $node): ?string
     {
         if ($node instanceof Node\Scalar\String_) {
             return $node->value;
         }
 
         if ($node instanceof Node\Expr\BinaryOp\Concat) {
-            if (null === $left = $this->getStringValue($node->left)) {
-                return null;
-            }
-
-            if (null === $right = $this->getStringValue($node->right)) {
-                return null;
-            }
-
-            return $left.$right;
+            return $this->getStringValueFromConcatNode($node);
         }
 
         if ($node instanceof Node\Expr\Assign && $node->expr instanceof Node\Scalar\String_) {
@@ -131,5 +123,18 @@ abstract class AbstractVisitor
         }
 
         return null;
+    }
+
+    private function getStringValueFromConcatNode(Node\Expr\BinaryOp\Concat $node): ?string
+    {
+        if (null === $left = $this->getStringValue($node->left)) {
+            return null;
+        }
+
+        if (null === $right = $this->getStringValue($node->right)) {
+            return null;
+        }
+
+        return $left.$right;
     }
 }

--- a/src/Symfony/Component/Translation/Extractor/Visitor/BackedEnumVisitor.php
+++ b/src/Symfony/Component/Translation/Extractor/Visitor/BackedEnumVisitor.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Extractor\Visitor;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitor;
+use Symfony\Contracts\Translation\TranslatableInterface;
+
+final class BackedEnumVisitor extends AbstractVisitor implements NodeVisitor
+{
+    /**
+     * Stores whether the current class is a translatable backed enum across visits of all children nodes.
+     */
+    private bool $isBackedEnum = false;
+    private array $cases = [];
+
+    public function beforeTraverse(array $nodes): ?Node
+    {
+        return null;
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        if (!$this->isBackedEnum($node)) {
+            return null;
+        }
+
+        if ($node instanceof Node\Stmt\EnumCase) {
+            $this->visitEnumCase($node);
+        }
+
+        if ($node instanceof Node\Expr\MethodCall) {
+            $this->visitTransMethodCall($node);
+        }
+
+        return null;
+    }
+
+    public function leaveNode(Node $node): ?Node
+    {
+        if ($node instanceof Node\Stmt\Enum_) {
+            $this->isBackedEnum = false;
+        }
+
+        return null;
+    }
+
+    public function afterTraverse(array $nodes): ?Node
+    {
+        return null;
+    }
+
+    private function visitEnumCase(Node\Stmt\EnumCase $node): void
+    {
+        $this->cases[$node->name->name] = $node->expr->value;
+    }
+
+    private function visitTransMethodCall(Node\Expr\MethodCall $node): void
+    {
+        if (!\is_string($node->name) && !$node->name instanceof Node\Identifier && !$node->name instanceof Node\Name) {
+            return;
+        }
+
+        $name = $node->name instanceof Node\Name ? $node->name->getLast() : (string) $node->name;
+        if ('trans' !== $name && 't' !== $name) {
+            return;
+        }
+
+        $firstNamedArgumentIndex = $this->nodeFirstNamedArgumentIndex($node);
+        $nodeId = $node->getArgs()[0 < $firstNamedArgumentIndex ? 0 : 'id'];
+        $domain = $this->getStringArguments($node, 2 < $firstNamedArgumentIndex ? 2 : 'domain')[0] ?? null;
+
+        $messagePattern = $this->resolveMessagePattern($nodeId->value);
+        if (null === $messagePattern) {
+            return;
+        }
+
+        foreach ($this->cases as $name => $value) {
+            $message = str_replace(
+                ['{name}', '{value}'],
+                [$name, $value],
+                $messagePattern
+            );
+
+            $this->addMessageToCatalogue($message, $domain, $node->getStartLine());
+        }
+    }
+
+    private function resolveMessagePattern(Node\Expr $expr): ?string
+    {
+        $parts = [];
+
+        while ($expr instanceof Node\Expr\BinaryOp\Concat) {
+            $parts[] = $this->resolveExprPart($expr->right);
+            $expr = $expr->left;
+        }
+
+        $parts[] = $this->resolveExprPart($expr);
+
+        // If there is only one string part and does not contain sprintf value(s), TransMethodVisitor already extracted the key.
+        if (1 === \count($parts) && !str_contains($parts[0], '{value}') && !str_contains($parts[0], '{name}')) {
+            return null;
+        }
+
+        $parts = array_reverse($parts);
+
+        // If any part failed to resolve, abort
+        if (\in_array(null, $parts, true)) {
+            return null;
+        }
+
+        return implode('', $parts);
+    }
+
+    private function resolveExprPart(Node\Expr $expr): ?string
+    {
+        if ($expr instanceof Node\Scalar\String_) {
+            return $expr->value;
+        }
+
+        if (
+            $expr instanceof Node\Expr\PropertyFetch
+            && $expr->var instanceof Node\Expr\Variable
+            && 'this' === $expr->var->name
+            && $expr->name instanceof Node\Identifier
+        ) {
+            if ('value' === $expr->name->name) {
+                return '{value}';
+            }
+
+            if ('name' === $expr->name->name) {
+                return '{name}';
+            }
+        }
+
+        if (
+            $expr instanceof Node\Expr\FuncCall
+            && 'sprintf' === $expr->name->name
+        ) {
+            $args = $expr->args;
+            $pattern = array_shift($args)->value->value;
+            array_walk($args, fn (Node\Arg &$arg) => $arg = $this->resolveExprPart($arg->value));
+
+            return vsprintf($pattern, $args);
+        }
+
+        return null;
+    }
+
+    private function isBackedEnum(Node $node): bool
+    {
+        if ($node instanceof Node\Stmt\Enum_) {
+            foreach ($node->implements as $interface) {
+                if (TranslatableInterface::class === $interface->name) {
+                    $this->isBackedEnum = true;
+                    break;
+                }
+            }
+        }
+
+        return $this->isBackedEnum;
+    }
+}

--- a/src/Symfony/Component/Translation/Extractor/Visitor/FormTypeVisitor.php
+++ b/src/Symfony/Component/Translation/Extractor/Visitor/FormTypeVisitor.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Extractor\Visitor;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitor;
+use Symfony\Component\Form\AbstractType;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@protonmail.com>
+ *
+ * Code mostly comes from https://github.com/php-translation/extractor/blob/master/src/Visitor/Php/Symfony/
+ */
+final class FormTypeVisitor extends AbstractVisitor implements NodeVisitor
+{
+    /**
+     * Stores whether the current class is a form type across visits of all children nodes.
+     */
+    private bool $isFormType = false;
+
+    public function beforeTraverse(array $nodes): ?Node
+    {
+        return null;
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        if (!$this->isFormType($node)) {
+            return null;
+        }
+
+        // Visit all array expressions to look for options array
+        if ($node instanceof Node\Expr\Array_) {
+            $this->visitOptionsArray($node);
+        }
+
+        // Visit all "add()" method calls to look for implicit labels
+        if ($node instanceof Node\Expr\MethodCall) {
+            $this->visitAddMethodCall($node);
+        }
+
+        return null;
+    }
+
+    public function leaveNode(Node $node): ?Node
+    {
+        if ($node instanceof Node\Stmt\Class_) {
+            $this->isFormType = false;
+        }
+
+        return null;
+    }
+
+    public function afterTraverse(array $nodes): ?Node
+    {
+        return null;
+    }
+
+    private function visitAddMethodCall(Node\Expr\MethodCall $node): void
+    {
+        if ('add' !== $node->name->name) {
+            return;
+        }
+
+        if (!$node->args[0]->value instanceof Node\Scalar\String_) {
+            return;
+        }
+
+        if (\count($node->args) === 1) {
+            $this->addMessageToCatalogue($this->getStringValue($node->args[0]->value), 'messages', $node->args[0]->value->getStartLine());
+        }
+    }
+
+    private function visitOptionsArray(Node\Expr\Array_ $node): void
+    {
+        $translatableOptions = ['label', 'placeholder', 'help'];
+
+        foreach ($node->items as $item) {
+            if (!$item->key instanceof Node\Scalar\String_ || !\in_array($item->key->value, $translatableOptions, true)) {
+                continue;
+            }
+
+            // If the option is a non-empty string, add it to the messages
+            $stringValue = $this->getStringValue($item->value);
+            if (null !== $stringValue && '' !== $stringValue) {
+                $this->addMessageToCatalogue($stringValue, 'messages', $item->getStartLine());
+            }
+        }
+    }
+
+    private function isFormType(Node $node): bool
+    {
+        if ($node instanceof Node\Stmt\Class_) {
+            if (null !== $node->extends && $node->extends->isFullyQualified() && AbstractType::class === $node->extends->name) {
+                $this->isFormType = true;
+            }
+        }
+
+        return $this->isFormType;
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Extractor/PhpAstExtractorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/PhpAstExtractorTest.php
@@ -183,6 +183,35 @@ final class PhpAstExtractorTest extends TestCase
         $this->assertEquals(['sources' => [$filename.':37']], $catalogue->getMetadata('other-domain-test-no-params-short-array', 'not_messages'));
     }
 
+    public function testExtractFiles()
+    {
+        $fixturesFolder = __DIR__.'/../Fixtures/extractor-php-ast/extract-files/';
+        $extractor = new PhpAstExtractor([new TransMethodVisitor()]);
+        $catalogue = new MessageCatalogue('en');
+
+        $extractor->extract($fixturesFolder, $catalogue);
+
+        $this->assertEquals(['messages' => ['example' => 'example']], $catalogue->all());
+        $this->assertEqualsCanonicalizing([
+            'sources' => [
+                $fixturesFolder.'translation.html.php:1',
+                $fixturesFolder.'translatable-short.html.php:1',
+                $fixturesFolder.'translatable-short-fqn.html.php:1',
+            ],
+        ], $catalogue->getMetadata('example'));
+    }
+
+    public function testCanBeExtracted()
+    {
+        $fixturesFolder = __DIR__.'/../Fixtures/extractor-php-ast/extract-files/';
+        $extractor = new PhpAstExtractor([new TransMethodVisitor()]);
+        $phpFiles = glob($fixturesFolder.'*.php');
+
+        foreach ($phpFiles as $file) {
+            $this->assertTrue($extractor->canBeExtracted($file), \sprintf('Current PHP file: %s', $file));
+        }
+    }
+
     public function testExtractionFromIndentedHeredocNowdoc()
     {
         $catalogue = new MessageCatalogue('en');

--- a/src/Symfony/Component/Translation/Tests/Extractor/Visitor/AbstractVisitorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/Visitor/AbstractVisitorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Extractor\Visitor;
+
+use PhpParser\NodeVisitor;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Extractor\PhpAstExtractor;
+use Symfony\Component\Translation\MessageCatalogue;
+
+abstract class AbstractVisitorTest extends TestCase
+{
+    abstract public function getVisitor(): NodeVisitor;
+
+    abstract public function getResource(): iterable|string;
+
+    abstract public function assertCatalogue(MessageCatalogue $catalogue): void;
+
+    public function testVisitor()
+    {
+        $extractor = new PhpAstExtractor([$this->getVisitor()]);
+        $extractor->setPrefix('prefix');
+        $catalogue = new MessageCatalogue('en');
+
+        $extractor->extract($this->getResource(), $catalogue);
+
+        $this->assertCatalogue($catalogue);
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Extractor/Visitor/BackedEnumVisitorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/Visitor/BackedEnumVisitorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Extractor\Visitor;
+
+use PhpParser\NodeVisitor;
+use Symfony\Component\Translation\Extractor\Visitor\BackedEnumVisitor;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class BackedEnumVisitorTest extends AbstractVisitorTest
+{
+    private const FIXTURES_FOLDER = __DIR__.'/../../Fixtures/extractor-php-ast/backed-enum-visitor/';
+
+    public function getVisitor(): BackedEnumVisitor
+    {
+        return new BackedEnumVisitor();
+    }
+
+    public function getResource(): iterable|string
+    {
+        return self::FIXTURES_FOLDER;
+    }
+
+    public function assertCatalogue(MessageCatalogue $catalogue): void
+    {
+        $this->assertEquals(
+            [
+                'messages' => [
+                    'backed_enum.value_concatenation.foo' => 'prefixbacked_enum.value_concatenation.foo',
+                    'backed_enum.name_concatenation.Foo' => 'prefixbacked_enum.name_concatenation.Foo',
+                    'backed_enum.value_concatenation.foo.label' => 'prefixbacked_enum.value_concatenation.foo.label',
+                    'backed_enum.both_concatenation.Foo_foo' => 'prefixbacked_enum.both_concatenation.Foo_foo',
+                    'backed_enum.value_concatenation.0' => 'prefixbacked_enum.value_concatenation.0',
+                    'backed_enum.value_sprintf.foo' => 'prefixbacked_enum.value_sprintf.foo',
+                    'backed_enum.value_sprintf.Foo.foo' => 'prefixbacked_enum.value_sprintf.Foo.foo',
+                    'backed_enum.value_sprintf.foo.name_concatenation.Foo' => 'prefixbacked_enum.value_sprintf.foo.name_concatenation.Foo',
+                ],
+            ],
+            $catalogue->all(),
+        );
+
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'backed-enum.html.php:13']], $catalogue->getMetadata('backed_enum.value_concatenation.foo'));
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Extractor/Visitor/ConstraintVisitorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/Visitor/ConstraintVisitorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Extractor\Visitor;
+
+use PhpParser\NodeVisitor;
+use Symfony\Component\Translation\Extractor\Visitor\ConstraintVisitor;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class ConstraintVisitorTest extends AbstractVisitorTest
+{
+    private const FIXTURES_FOLDER = __DIR__.'/../../Fixtures/extractor-php-ast/constraint-visitor/';
+
+    public function getVisitor(): NodeVisitor
+    {
+        return new ConstraintVisitor(['NotBlank', 'Isbn', 'Length']);
+    }
+
+    public function getResource(): iterable|string
+    {
+        return self::FIXTURES_FOLDER;
+    }
+
+    public function assertCatalogue(MessageCatalogue $catalogue): void
+    {
+        $this->assertEquals(
+            [
+                'validators' => [
+                    'message-in-constraint-attribute' => 'prefixmessage-in-constraint-attribute',
+                    // 'custom Isbn message from attribute' => 'prefixcustom Isbn message from attribute',
+                    'custom Isbn message from attribute with options as array' => 'prefixcustom Isbn message from attribute with options as array',
+                    'custom Length exact message from attribute from named argument' => 'prefixcustom Length exact message from attribute from named argument',
+                    'custom Length exact message from attribute from named argument 1/2' => 'prefixcustom Length exact message from attribute from named argument 1/2',
+                    'custom Length min message from attribute from named argument 2/2' => 'prefixcustom Length min message from attribute from named argument 2/2',
+                    // 'custom Isbn message' => 'prefixcustom Isbn message',
+                    'custom Isbn message with options as array' => 'prefixcustom Isbn message with options as array',
+                    'custom Isbn message from named argument' => 'prefixcustom Isbn message from named argument',
+                    'custom Length exact message from named argument' => 'prefixcustom Length exact message from named argument',
+                    'custom Length exact message from named argument 1/2' => 'prefixcustom Length exact message from named argument 1/2',
+                    'custom Length min message from named argument 2/2' => 'prefixcustom Length min message from named argument 2/2',
+                ],
+            ],
+            $catalogue->all(),
+        );
+
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'validator-constraints.php:8']], $catalogue->getMetadata('message-in-constraint-attribute', 'validators'));
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Extractor/Visitor/FormTypeVisitorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/Visitor/FormTypeVisitorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Extractor\Visitor;
+
+use PhpParser\NodeVisitor;
+use Symfony\Component\Translation\Extractor\Visitor\FormTypeVisitor;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class FormTypeVisitorTest extends AbstractVisitorTest
+{
+    private const FIXTURES_FOLDER = __DIR__.'/../../Fixtures/extractor-php-ast/form-type-visitor/';
+
+    public function getVisitor(): FormTypeVisitor
+    {
+        return new FormTypeVisitor();
+    }
+
+    public function getResource(): iterable|string
+    {
+        return self::FIXTURES_FOLDER;
+    }
+
+    public function assertCatalogue(MessageCatalogue $catalogue): void
+    {
+        $this->assertEquals(
+            [
+                'messages' => [
+                    'label.foo1' => 'prefixlabel.foo1',
+                    'label.find1' => 'prefixlabel.find1',
+                    'find2' => 'prefixfind2',
+                    'FOUND3' => 'prefixFOUND3',
+                    'label.find4' => 'prefixlabel.find4',
+                    'label.find5' => 'prefixlabel.find5',
+                    'find6' => 'prefixfind6',
+                    'bigger_find7' => 'prefixbigger_find7',
+                    'camelFind8' => 'prefixcamelFind8',
+                    'label.find9' => 'prefixlabel.find9',
+                    'placeholder.foo1' => 'prefixplaceholder.foo1',
+                    'help.foo1' => 'prefixhelp.foo1',
+                    'placeholder.find4' => 'prefixplaceholder.find4',
+                    'help.find4' => 'prefixhelp.find4',
+                    'placeholder.find5' => 'prefixplaceholder.find5',
+                    'help.find5' => 'prefixhelp.find5',
+                ],
+            ],
+            $catalogue->all(),
+        );
+
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'form-type.php:29']], $catalogue->getMetadata('label.find1'));
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Extractor/Visitor/TransMethodVisitorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/Visitor/TransMethodVisitorTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Extractor\Visitor;
+
+use PhpParser\NodeVisitor;
+use Symfony\Component\Translation\Extractor\Visitor\TransMethodVisitor;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class TransMethodVisitorTest extends AbstractVisitorTest
+{
+    private const FIXTURES_FOLDER = __DIR__.'/../../Fixtures/extractor-php-ast/trans-method-visitor/';
+    public const OTHER_DOMAIN = 'not_messages';
+
+    public function getVisitor(): NodeVisitor
+    {
+        return new TransMethodVisitor();
+    }
+
+    public function getResource(): iterable|string
+    {
+        return self::FIXTURES_FOLDER;
+    }
+
+    public function assertCatalogue(MessageCatalogue $catalogue): void
+    {
+        $expectedHeredoc = <<<EOF
+            heredoc key with whitespace and escaped \$\n sequences
+            EOF;
+        $expectedNowdoc = <<<'EOF'
+            nowdoc key with whitespace and nonescaped \$\n sequences
+            EOF;
+
+        $this->assertEquals(
+            [
+                'messages' => [
+                    'single-quoted key' => 'prefixsingle-quoted key',
+                    'double-quoted key' => 'prefixdouble-quoted key',
+                    'heredoc key' => 'prefixheredoc key',
+                    'nowdoc key' => 'prefixnowdoc key',
+                    "double-quoted key with whitespace and escaped \$\n\" sequences" => "prefixdouble-quoted key with whitespace and escaped \$\n\" sequences",
+                    'single-quoted key with whitespace and nonescaped \\$\\n\' sequences' => 'prefixsingle-quoted key with whitespace and nonescaped \\$\\n\' sequences',
+                    $expectedHeredoc => 'prefix'.$expectedHeredoc,
+                    $expectedNowdoc => 'prefix'.$expectedNowdoc,
+                    'single-quoted key with "quote mark at the end"' => 'prefixsingle-quoted key with "quote mark at the end"',
+                    'concatenated message with heredoc and nowdoc' => 'prefixconcatenated message with heredoc and nowdoc',
+                    'default domain' => 'prefixdefault domain',
+                    'mix-named-arguments' => 'prefixmix-named-arguments',
+                    'mix-named-arguments-locale' => 'prefixmix-named-arguments-locale',
+                    'mix-named-arguments-without-domain' => 'prefixmix-named-arguments-without-domain',
+                    "heredoc\nindented\n  further" => "prefixheredoc\nindented\n  further",
+                    "nowdoc\nindented\n  further" => "prefixnowdoc\nindented\n  further",
+                    'translatable-short single-quoted key' => 'prefixtranslatable-short single-quoted key',
+                    'translatable-short double-quoted key' => 'prefixtranslatable-short double-quoted key',
+                    'translatable-short heredoc key' => 'prefixtranslatable-short heredoc key',
+                    'translatable-short nowdoc key' => 'prefixtranslatable-short nowdoc key',
+                    "translatable-short double-quoted key with whitespace and escaped \$\n\" sequences" => "prefixtranslatable-short double-quoted key with whitespace and escaped \$\n\" sequences",
+                    'translatable-short single-quoted key with whitespace and nonescaped \$\n\' sequences' => 'prefixtranslatable-short single-quoted key with whitespace and nonescaped \$\n\' sequences',
+                    'translatable-short single-quoted key with "quote mark at the end"' => 'prefixtranslatable-short single-quoted key with "quote mark at the end"',
+                    'translatable-short '.$expectedHeredoc => 'prefixtranslatable-short '.$expectedHeredoc,
+                    'translatable-short '.$expectedNowdoc => 'prefixtranslatable-short '.$expectedNowdoc,
+                    'translatable-short concatenated message with heredoc and nowdoc' => 'prefixtranslatable-short concatenated message with heredoc and nowdoc',
+                    'translatable-short default domain' => 'prefixtranslatable-short default domain',
+                    'translatable-short-fqn single-quoted key' => 'prefixtranslatable-short-fqn single-quoted key',
+                    'translatable-short-fqn double-quoted key' => 'prefixtranslatable-short-fqn double-quoted key',
+                    'translatable-short-fqn heredoc key' => 'prefixtranslatable-short-fqn heredoc key',
+                    'translatable-short-fqn nowdoc key' => 'prefixtranslatable-short-fqn nowdoc key',
+                    "translatable-short-fqn double-quoted key with whitespace and escaped \$\n\" sequences" => "prefixtranslatable-short-fqn double-quoted key with whitespace and escaped \$\n\" sequences",
+                    'translatable-short-fqn single-quoted key with whitespace and nonescaped \$\n\' sequences' => 'prefixtranslatable-short-fqn single-quoted key with whitespace and nonescaped \$\n\' sequences',
+                    'translatable-short-fqn single-quoted key with "quote mark at the end"' => 'prefixtranslatable-short-fqn single-quoted key with "quote mark at the end"',
+                    'translatable-short-fqn '.$expectedHeredoc => 'prefixtranslatable-short-fqn '.$expectedHeredoc,
+                    'translatable-short-fqn '.$expectedNowdoc => 'prefixtranslatable-short-fqn '.$expectedNowdoc,
+                    'translatable-short-fqn concatenated message with heredoc and nowdoc' => 'prefixtranslatable-short-fqn concatenated message with heredoc and nowdoc',
+                    'translatable-short-fqn default domain' => 'prefixtranslatable-short-fqn default domain',
+                    'text_align.left.label' => 'prefixtext_align.left.label',
+                    'text_align.center.label' => 'prefixtext_align.center.label',
+                    'text_align.right.label' => 'prefixtext_align.right.label',
+                ],
+                'not_messages' => [
+                    'other-domain-test-no-params-short-array' => 'prefixother-domain-test-no-params-short-array',
+                    'other-domain-test-no-params-long-array' => 'prefixother-domain-test-no-params-long-array',
+                    'other-domain-test-params-short-array' => 'prefixother-domain-test-params-short-array',
+                    'other-domain-test-params-long-array' => 'prefixother-domain-test-params-long-array',
+                    'typecast' => 'prefixtypecast',
+                    'ordered-named-arguments-in-trans-method' => 'prefixordered-named-arguments-in-trans-method',
+                    'disordered-named-arguments-in-trans-method' => 'prefixdisordered-named-arguments-in-trans-method',
+                    'variable-assignation-inlined-in-trans-method-call1' => 'prefixvariable-assignation-inlined-in-trans-method-call1',
+                    'variable-assignation-inlined-in-trans-method-call2' => 'prefixvariable-assignation-inlined-in-trans-method-call2',
+                    'variable-assignation-inlined-in-trans-method-call3' => 'prefixvariable-assignation-inlined-in-trans-method-call3',
+                    'variable-assignation-inlined-with-named-arguments-in-trans-method' => 'prefixvariable-assignation-inlined-with-named-arguments-in-trans-method',
+                    'mix-named-arguments-without-parameters' => 'prefixmix-named-arguments-without-parameters',
+                    'mix-named-arguments-disordered' => 'prefixmix-named-arguments-disordered',
+                    'const-domain' => 'prefixconst-domain',
+                    'translatable-short other-domain-test-no-params-short-array' => 'prefixtranslatable-short other-domain-test-no-params-short-array',
+                    'translatable-short other-domain-test-no-params-long-array' => 'prefixtranslatable-short other-domain-test-no-params-long-array',
+                    'translatable-short other-domain-test-params-short-array' => 'prefixtranslatable-short other-domain-test-params-short-array',
+                    'translatable-short other-domain-test-params-long-array' => 'prefixtranslatable-short other-domain-test-params-long-array',
+                    'translatable-short typecast' => 'prefixtranslatable-short typecast',
+                    'translatable-short-fqn other-domain-test-no-params-short-array' => 'prefixtranslatable-short-fqn other-domain-test-no-params-short-array',
+                    'translatable-short-fqn other-domain-test-no-params-long-array' => 'prefixtranslatable-short-fqn other-domain-test-no-params-long-array',
+                    'translatable-short-fqn other-domain-test-params-short-array' => 'prefixtranslatable-short-fqn other-domain-test-params-short-array',
+                    'translatable-short-fqn other-domain-test-params-long-array' => 'prefixtranslatable-short-fqn other-domain-test-params-long-array',
+                    'translatable-short-fqn typecast' => 'prefixtranslatable-short-fqn typecast',
+                ],
+            ],
+            $catalogue->all(),
+        );
+
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translation.html.php:2']], $catalogue->getMetadata('single-quoted key'));
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translation.html.php:37']], $catalogue->getMetadata('other-domain-test-no-params-short-array', 'not_messages'));
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translation-73.html.php:8']], $catalogue->getMetadata("nowdoc\nindented\n  further"));
+
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translatable-short.html.php:2']], $catalogue->getMetadata('translatable-short single-quoted key'));
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translatable-short.html.php:37']], $catalogue->getMetadata('translatable-short other-domain-test-no-params-short-array', 'not_messages'));
+
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translatable-short-fqn.html.php:2']], $catalogue->getMetadata('translatable-short-fqn single-quoted key'));
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translatable-short-fqn.html.php:37']], $catalogue->getMetadata('translatable-short-fqn other-domain-test-no-params-short-array', 'not_messages'));
+
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translatable-backed-enum.html.php:17']], $catalogue->getMetadata('text_align.left.label'));
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Extractor/Visitor/TranslatableMessageVisitorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/Visitor/TranslatableMessageVisitorTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Extractor\Visitor;
+
+use PhpParser\NodeVisitor;
+use Symfony\Component\Translation\Extractor\Visitor\TranslatableMessageVisitor;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class TranslatableMessageVisitorTest extends AbstractVisitorTest
+{
+    private const FIXTURES_FOLDER = __DIR__.'/../../Fixtures/extractor-php-ast/translatable-message-visitor/';
+
+    public function getVisitor(): NodeVisitor
+    {
+        return new TranslatableMessageVisitor();
+    }
+
+    public function getResource(): iterable|string
+    {
+        return self::FIXTURES_FOLDER;
+    }
+
+    public function assertCatalogue(MessageCatalogue $catalogue): void
+    {
+        $expectedHeredoc = <<<EOF
+            heredoc key with whitespace and escaped \$\n sequences
+            EOF;
+        $expectedNowdoc = <<<'EOF'
+            nowdoc key with whitespace and nonescaped \$\n sequences
+            EOF;
+
+        $this->assertEquals(
+            [
+                'messages' => [
+                    'translatable single-quoted key' => 'prefixtranslatable single-quoted key',
+                    'translatable double-quoted key' => 'prefixtranslatable double-quoted key',
+                    'translatable heredoc key' => 'prefixtranslatable heredoc key',
+                    'translatable nowdoc key' => 'prefixtranslatable nowdoc key',
+                    "translatable double-quoted key with whitespace and escaped \$\n\" sequences" => "prefixtranslatable double-quoted key with whitespace and escaped \$\n\" sequences",
+                    'translatable single-quoted key with whitespace and nonescaped \$\n\' sequences' => 'prefixtranslatable single-quoted key with whitespace and nonescaped \$\n\' sequences',
+                    'translatable single-quoted key with "quote mark at the end"' => 'prefixtranslatable single-quoted key with "quote mark at the end"',
+                    'translatable '.$expectedHeredoc => 'prefixtranslatable '.$expectedHeredoc,
+                    'translatable '.$expectedNowdoc => 'prefixtranslatable '.$expectedNowdoc,
+                    'translatable concatenated message with heredoc and nowdoc' => 'prefixtranslatable concatenated message with heredoc and nowdoc',
+                    'translatable default domain' => 'prefixtranslatable default domain',
+                    'translatable-fqn single-quoted key' => 'prefixtranslatable-fqn single-quoted key',
+                    'translatable-fqn double-quoted key' => 'prefixtranslatable-fqn double-quoted key',
+                    'translatable-fqn heredoc key' => 'prefixtranslatable-fqn heredoc key',
+                    'translatable-fqn nowdoc key' => 'prefixtranslatable-fqn nowdoc key',
+                    "translatable-fqn double-quoted key with whitespace and escaped \$\n\" sequences" => "prefixtranslatable-fqn double-quoted key with whitespace and escaped \$\n\" sequences",
+                    'translatable-fqn single-quoted key with whitespace and nonescaped \$\n\' sequences' => 'prefixtranslatable-fqn single-quoted key with whitespace and nonescaped \$\n\' sequences',
+                    'translatable-fqn single-quoted key with "quote mark at the end"' => 'prefixtranslatable-fqn single-quoted key with "quote mark at the end"',
+                    'translatable-fqn '.$expectedHeredoc => 'prefixtranslatable-fqn '.$expectedHeredoc,
+                    'translatable-fqn '.$expectedNowdoc => 'prefixtranslatable-fqn '.$expectedNowdoc,
+                    'translatable-fqn concatenated message with heredoc and nowdoc' => 'prefixtranslatable-fqn concatenated message with heredoc and nowdoc',
+                    'translatable-fqn default domain' => 'prefixtranslatable-fqn default domain',
+                ],
+                'not_messages' => [
+                    'translatable other-domain-test-no-params-short-array' => 'prefixtranslatable other-domain-test-no-params-short-array',
+                    'translatable other-domain-test-no-params-long-array' => 'prefixtranslatable other-domain-test-no-params-long-array',
+                    'translatable other-domain-test-params-short-array' => 'prefixtranslatable other-domain-test-params-short-array',
+                    'translatable other-domain-test-params-long-array' => 'prefixtranslatable other-domain-test-params-long-array',
+                    'translatable typecast' => 'prefixtranslatable typecast',
+                    'translatable-fqn other-domain-test-no-params-short-array' => 'prefixtranslatable-fqn other-domain-test-no-params-short-array',
+                    'translatable-fqn other-domain-test-no-params-long-array' => 'prefixtranslatable-fqn other-domain-test-no-params-long-array',
+                    'translatable-fqn other-domain-test-params-short-array' => 'prefixtranslatable-fqn other-domain-test-params-short-array',
+                    'translatable-fqn other-domain-test-params-long-array' => 'prefixtranslatable-fqn other-domain-test-params-long-array',
+                    'translatable-fqn typecast' => 'prefixtranslatable-fqn typecast',
+                ],
+            ],
+            $catalogue->all(),
+        );
+
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translatable.html.php:2']], $catalogue->getMetadata('translatable single-quoted key'));
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translatable.html.php:37']], $catalogue->getMetadata('translatable other-domain-test-no-params-short-array', 'not_messages'));
+
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translatable-fqn.html.php:2']], $catalogue->getMetadata('translatable-fqn single-quoted key'));
+        $this->assertEquals(['sources' => [self::FIXTURES_FOLDER.'translatable-fqn.html.php:37']], $catalogue->getMetadata('translatable-fqn other-domain-test-no-params-short-array', 'not_messages'));
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/backed-enum-visitor/backed-enum.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/backed-enum-visitor/backed-enum.html.php
@@ -1,0 +1,85 @@
+This template is used for translation message extraction tests
+<?php
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+enum BackedEnumWithValueConcatenationAtTheEnd: string implements TranslatableInterface
+{
+    case Foo = 'foo';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans('backed_enum.value_concatenation.'.$this->value, locale: $locale);
+    }
+}
+
+enum BackedEnumWithNameConcatenationAtTheEnd: string implements TranslatableInterface
+{
+    case Foo = 'foo';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans('backed_enum.name_concatenation.'.$this->name, locale: $locale);
+    }
+}
+
+enum BackedEnumWithValueConcatenationInTheMiddle: string implements TranslatableInterface
+{
+    case Foo = 'foo';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans('backed_enum.value_concatenation.'.$this->value.'.label', locale: $locale);
+    }
+}
+
+enum BackedEnumWithBothConcatenation: string implements TranslatableInterface
+{
+    case Foo = 'foo';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans('backed_enum.both_concatenation.'.$this->name.'_'.$this->value, locale: $locale);
+    }
+}
+
+enum BackedEnumWithIntergerScalarType: int implements TranslatableInterface
+{
+    case Foo = 0;
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans('backed_enum.value_concatenation.'.$this->value, locale: $locale);
+    }
+}
+
+enum BackedEnumWithSprintf: string implements TranslatableInterface
+{
+    case Foo = 'foo';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans(sprintf('backed_enum.value_sprintf.%s', $this->value), locale: $locale);
+    }
+}
+
+enum BackedEnumWithTwoArgumentsInSprintf: string implements TranslatableInterface
+{
+    case Foo = 'foo';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans(sprintf('backed_enum.value_sprintf.%s.%s', $this->name, $this->value), locale: $locale);
+    }
+}
+
+enum BackedEnumWithSprintfAndConcatenation: string implements TranslatableInterface
+{
+    case Foo = 'foo';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans(sprintf('backed_enum.value_sprintf.%s', $this->value).'.name_concatenation.'.$this->name, locale: $locale);
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/constraint-visitor/validator-constraints.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/constraint-visitor/validator-constraints.php
@@ -1,0 +1,40 @@
+This template is used for translation message extraction tests
+<?php
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class Foo
+{
+    #[Assert\NotBlank(message: 'message-in-constraint-attribute')]
+    public string $bar;
+
+    #[Assert\Length(exactMessage: 'custom Length exact message from attribute from named argument')]
+    public string $bar2;
+
+    #[Assert\Length(exactMessage: 'custom Length exact message from attribute from named argument 1/2', minMessage: 'custom Length min message from attribute from named argument 2/2')]
+    public string $bar3;
+
+    #[Assert\Isbn('isbn10', 'custom Isbn message from attribute')] // no way to handle those arguments (not named, not in associative array).
+    public string $isbn;
+
+    #[Assert\Isbn([
+        'type' => 'isbn10',
+        'message' => 'custom Isbn message from attribute with options as array',
+    ])]
+    public string $isbn2;
+}
+
+class Foo2
+{
+    public function index()
+    {
+        $constraint1 = new Assert\Isbn('isbn10', 'custom Isbn message'); // no way to handle those arguments (not named, not in associative array).
+        $constraint2 = new Assert\Isbn([
+            'type' => 'isbn10',
+            'message' => 'custom Isbn message with options as array',
+        ]);
+        $constraint3 = new Assert\Isbn(message: 'custom Isbn message from named argument');
+        $constraint4 = new Assert\Length(exactMessage: 'custom Length exact message from named argument');
+        $constraint5 = new Assert\Length(exactMessage: 'custom Length exact message from named argument 1/2', minMessage: 'custom Length min message from named argument 2/2');
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/form-type.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/form-type.php
@@ -1,0 +1,16 @@
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class FooType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('foo1', null, [
+            'label' => 'label.foo1',
+            'placeholder' => 'placeholder.foo1',
+            'help' => 'help.foo1',
+        ]);
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/translatable-fqn.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/translatable-fqn.html.php
@@ -1,0 +1,1 @@
+<?php new \Symfony\Component\Translation\TranslatableMessage('example'); ?>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/translatable-short-fqn.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/translatable-short-fqn.html.php
@@ -1,0 +1,1 @@
+<?php \Symfony\Component\Translation\t('example'); ?>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/translatable-short.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/translatable-short.html.php
@@ -1,0 +1,1 @@
+<?php t('example'); ?>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/translatable.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/translatable.html.php
@@ -1,0 +1,1 @@
+<?php new TranslatableMessage('example'); ?>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/translation.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/translation.html.php
@@ -1,0 +1,1 @@
+<?php echo $view['translator']->trans('example'); ?>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/validator-constraints.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/extract-files/validator-constraints.php
@@ -1,0 +1,9 @@
+<?php
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class Foo
+{
+    #[Assert\NotBlank(message: 'message')]
+    public string $bar;
+}

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/form-type-visitor/form-type.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/form-type-visitor/form-type.php
@@ -1,0 +1,82 @@
+This template is used for translation message extraction tests
+<?php
+// @see https://github.com/php-translation/extractor/blob/master/tests/Resources/Php/Symfony/ExplicitLabelType.php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+// Intentionally not included in FormTypeVisitor constructor argument in PhpAstExtractorTest.php
+// To test that the visitor can find FormType extending AbstractType.
+class FooType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('foo1', null, [
+            'label' => 'label.foo1',
+            'placeholder' => 'placeholder.foo1',
+            'help' => 'help.foo1',
+        ]);
+    }
+}
+
+class ExtractionTestFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $var = "something";
+        $builder->add('find1', null, [
+            'label' => 'label.find1',
+        ]);
+        $builder
+            ->add('find2', null, array(
+                'label' => 'find2',
+            ))
+            ->add('field_longer_name3', null, [
+                'label' => 'FOUND3',
+            ])
+            ->add('skip1', null, [
+                'label' => $var, // shouldn't be picked up
+                'placeholder' => $var, // shouldn't be picked up
+                'help' => $var, // shouldn't be picked up
+                'somethingelse' => 'skipthis',
+            ])
+            ->add('skip2', null, [
+                'label' => PHP_OS, // constant shouldn't work
+                'placeholder' => PHP_OS, // constant shouldn't work
+                'help' => PHP_OS, // constant shouldn't work
+            ])
+            ->add('skip3', null, [
+                'label', // value label, shouldn't be picked up
+            ])
+            ->add('skip4', null, [
+                'label' => 'something '.$var, // string+var concatenation, shouldn't be picked up
+                'placeholder' => 'something '.$var, // string+var concatenation, shouldn't be picked up
+                'help' => 'something '.$var, // string+var concatenation, shouldn't be picked up
+            ])
+        ;
+
+        // add options in variable should be found
+        $opts = ['label'=>'label.find4','placeholder'=>'placeholder.find4','help'=>'help.find4'];
+        $builder->add('find4', null, $opts);
+
+        // empty options should be skipped
+        $builder->add('skip5', null, ['label'=>'', 'placeholder'=>'', 'help'=>'']);
+
+        // collection test
+        $builder->add('find5', CollectionType::class, [
+            'options' => [
+                'label' => 'label.find5',
+                'placeholder' => 'placeholder.find5',
+                'help' => 'help.find5',
+            ],
+        ]);
+
+        // implicit labels should be found
+        $builder->add('find6');
+        $builder->add('bigger_find7');
+        $builder->add('camelFind8');
+        $builder->add('skip6'.$var);
+        $builder->add('skip7', null, ['label'=>'label.find9']);
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/trans-method-visitor/translatable-backed-enum.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/trans-method-visitor/translatable-backed-enum.html.php
@@ -1,0 +1,22 @@
+This template is used for translation message extraction tests
+<?php
+// @See https://symfony.com/doc/current/reference/forms/types/enum.html#example-usage
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+enum TextAlign: string implements TranslatableInterface
+{
+    case Left = 'Left aligned';
+    case Center = 'Center aligned';
+    case Right = 'Right aligned';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return match ($this) {
+            self::Left  => $translator->trans('text_align.left.label', locale: $locale),
+            self::Center => $translator->trans('text_align.center.label', locale: $locale),
+            self::Right  => $translator->trans('text_align.right.label', locale: $locale),
+        };
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/trans-method-visitor/translatable-short-fqn.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/trans-method-visitor/translatable-short-fqn.html.php
@@ -1,0 +1,47 @@
+This template is used for translation message extraction tests
+<?php \Symfony\Component\Translation\t('translatable-short-fqn single-quoted key'); ?>
+<?php \Symfony\Component\Translation\t('translatable-short-fqn double-quoted key'); ?>
+<?php \Symfony\Component\Translation\t(<<<EOF
+translatable-short-fqn heredoc key
+EOF
+); ?>
+<?php \Symfony\Component\Translation\t(<<<'EOF'
+translatable-short-fqn nowdoc key
+EOF
+); ?>
+<?php \Symfony\Component\Translation\t(
+    "translatable-short-fqn double-quoted key with whitespace and escaped \$\n\" sequences"
+); ?>
+<?php \Symfony\Component\Translation\t(
+    'translatable-short-fqn single-quoted key with whitespace and nonescaped \$\n\' sequences'
+); ?>
+<?php \Symfony\Component\Translation\t(<<<EOF
+translatable-short-fqn heredoc key with whitespace and escaped \$\n sequences
+EOF
+); ?>
+<?php \Symfony\Component\Translation\t(<<<'EOF'
+translatable-short-fqn nowdoc key with whitespace and nonescaped \$\n sequences
+EOF
+); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn single-quoted key with "quote mark at the end"'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn concatenated'.' message'.<<<EOF
+ with heredoc
+EOF
+.<<<'EOF'
+ and nowdoc
+EOF
+); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn other-domain-test-no-params-short-array', [], 'not_messages'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn other-domain-test-no-params-long-array', [], 'not_messages'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn other-domain-test-params-short-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn other-domain-test-params-long-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn typecast', ['a' => (int) '123'], 'not_messages'); ?>
+
+<?php \Symfony\Component\Translation\t('translatable-short-fqn default domain', [], null); ?>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/trans-method-visitor/translatable-short.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/trans-method-visitor/translatable-short.html.php
@@ -1,0 +1,47 @@
+This template is used for translation message extraction tests
+<?php t('translatable-short single-quoted key'); ?>
+<?php t('translatable-short double-quoted key'); ?>
+<?php t(<<<EOF
+translatable-short heredoc key
+EOF
+); ?>
+<?php t(<<<'EOF'
+translatable-short nowdoc key
+EOF
+); ?>
+<?php t(
+    "translatable-short double-quoted key with whitespace and escaped \$\n\" sequences"
+); ?>
+<?php t(
+    'translatable-short single-quoted key with whitespace and nonescaped \$\n\' sequences'
+); ?>
+<?php t(<<<EOF
+translatable-short heredoc key with whitespace and escaped \$\n sequences
+EOF
+); ?>
+<?php t(<<<'EOF'
+translatable-short nowdoc key with whitespace and nonescaped \$\n sequences
+EOF
+); ?>
+
+<?php t('translatable-short single-quoted key with "quote mark at the end"'); ?>
+
+<?php t('translatable-short concatenated'.' message'.<<<EOF
+ with heredoc
+EOF
+.<<<'EOF'
+ and nowdoc
+EOF
+); ?>
+
+<?php t('translatable-short other-domain-test-no-params-short-array', [], 'not_messages'); ?>
+
+<?php t('translatable-short other-domain-test-no-params-long-array', [], 'not_messages'); ?>
+
+<?php t('translatable-short other-domain-test-params-short-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php t('translatable-short other-domain-test-params-long-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php t('translatable-short typecast', ['a' => (int) '123'], 'not_messages'); ?>
+
+<?php t('translatable-short default domain', [], null); ?>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/trans-method-visitor/translation-73.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/trans-method-visitor/translation-73.html.php
@@ -1,0 +1,13 @@
+This template is used for translation message extraction tests
+<?php echo $view['translator']->trans(<<<EOF
+    heredoc
+    indented
+      further
+    EOF
+); ?>
+<?php echo $view['translator']->trans(<<<'EOF'
+    nowdoc
+    indented
+      further
+    EOF
+); ?>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/trans-method-visitor/translation.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/trans-method-visitor/translation.html.php
@@ -1,0 +1,69 @@
+This template is used for translation message extraction tests
+<?php echo $view['translator']->trans('single-quoted key'); ?>
+<?php echo $view['translator']->trans('double-quoted key'); ?>
+<?php echo $view['translator']->trans(<<<EOF
+heredoc key
+EOF
+); ?>
+<?php echo $view['translator']->trans(<<<'EOF'
+nowdoc key
+EOF
+); ?>
+<?php echo $view['translator']->trans(
+    "double-quoted key with whitespace and escaped \$\n\" sequences"
+); ?>
+<?php echo $view['translator']->trans(
+    'single-quoted key with whitespace and nonescaped \$\n\' sequences'
+); ?>
+<?php echo $view['translator']->trans(<<<EOF
+heredoc key with whitespace and escaped \$\n sequences
+EOF
+); ?>
+<?php echo $view['translator']->trans(<<<'EOF'
+nowdoc key with whitespace and nonescaped \$\n sequences
+EOF
+); ?>
+
+<?php echo $view['translator']->trans('single-quoted key with "quote mark at the end"'); ?>
+
+<?php echo $view['translator']->trans('concatenated'.' message'.<<<EOF
+ with heredoc
+EOF
+.<<<'EOF'
+ and nowdoc
+EOF
+); ?>
+
+<?php echo $view['translator']->trans('other-domain-test-no-params-short-array', [], 'not_messages'); ?>
+
+<?php echo $view['translator']->trans('other-domain-test-no-params-long-array', [], 'not_messages'); ?>
+
+<?php echo $view['translator']->trans('other-domain-test-params-short-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php echo $view['translator']->trans('other-domain-test-params-long-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php echo $view['translator']->trans('typecast', ['a' => (int) '123'], 'not_messages'); ?>
+
+<?php echo $view['translator']->trans('default domain', [], null); ?>
+
+<?php echo $view['translator']->trans(id: 'ordered-named-arguments-in-trans-method', parameters: [], domain: 'not_messages'); ?>
+<?php echo $view['translator']->trans(domain: 'not_messages', id: 'disordered-named-arguments-in-trans-method', parameters: []); ?>
+
+<?php echo $view['translator']->trans($key = 'variable-assignation-inlined-in-trans-method-call1', $parameters = [], $domain = 'not_messages'); ?>
+<?php echo $view['translator']->trans('variable-assignation-inlined-in-trans-method-call2', $parameters = [], $domain = 'not_messages'); ?>
+<?php echo $view['translator']->trans('variable-assignation-inlined-in-trans-method-call3', [], $domain = 'not_messages'); ?>
+
+<?php echo $view['translator']->trans(domain: $domain = 'not_messages', id: $key = 'variable-assignation-inlined-with-named-arguments-in-trans-method', parameters: $parameters = []); ?>
+
+<?php echo $view['translator']->trans('mix-named-arguments', parameters: ['foo' => 'bar']); ?>
+<?php echo $view['translator']->trans('mix-named-arguments-locale', parameters: ['foo' => 'bar'], locale: 'de'); ?>
+<?php echo $view['translator']->trans('mix-named-arguments-without-domain', parameters: ['foo' => 'bar']); ?>
+<?php echo $view['translator']->trans('mix-named-arguments-without-parameters', domain: 'not_messages'); ?>
+<?php echo $view['translator']->trans('mix-named-arguments-disordered', domain: 'not_messages', parameters: []); ?>
+
+<?php echo $view['translator']->trans(...); // should not fail ?>
+
+<?php
+use Symfony\Component\Translation\Tests\Extractor\Visitor\TransMethodVisitorTest;
+echo $view['translator']->trans('const-domain', [], TransMethodVisitorTest::OTHER_DOMAIN);
+?>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/translatable-message-visitor/translatable-fqn.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/translatable-message-visitor/translatable-fqn.html.php
@@ -1,0 +1,47 @@
+This template is used for translation message extraction tests
+<?php new \Symfony\Component\Translation\TranslatableMessage('translatable-fqn single-quoted key'); ?>
+<?php new \Symfony\Component\Translation\TranslatableMessage('translatable-fqn double-quoted key'); ?>
+<?php new \Symfony\Component\Translation\TranslatableMessage(<<<EOF
+translatable-fqn heredoc key
+EOF
+); ?>
+<?php new \Symfony\Component\Translation\TranslatableMessage(<<<'EOF'
+translatable-fqn nowdoc key
+EOF
+); ?>
+<?php new \Symfony\Component\Translation\TranslatableMessage(
+    "translatable-fqn double-quoted key with whitespace and escaped \$\n\" sequences"
+); ?>
+<?php new \Symfony\Component\Translation\TranslatableMessage(
+    'translatable-fqn single-quoted key with whitespace and nonescaped \$\n\' sequences'
+); ?>
+<?php new \Symfony\Component\Translation\TranslatableMessage(<<<EOF
+translatable-fqn heredoc key with whitespace and escaped \$\n sequences
+EOF
+); ?>
+<?php new \Symfony\Component\Translation\TranslatableMessage(<<<'EOF'
+translatable-fqn nowdoc key with whitespace and nonescaped \$\n sequences
+EOF
+); ?>
+
+<?php new \Symfony\Component\Translation\TranslatableMessage('translatable-fqn single-quoted key with "quote mark at the end"'); ?>
+
+<?php new \Symfony\Component\Translation\TranslatableMessage('translatable-fqn concatenated'.' message'.<<<EOF
+ with heredoc
+EOF
+.<<<'EOF'
+ and nowdoc
+EOF
+); ?>
+
+<?php new \Symfony\Component\Translation\TranslatableMessage('translatable-fqn other-domain-test-no-params-short-array', [], 'not_messages'); ?>
+
+<?php new \Symfony\Component\Translation\TranslatableMessage('translatable-fqn other-domain-test-no-params-long-array', [], 'not_messages'); ?>
+
+<?php new \Symfony\Component\Translation\TranslatableMessage('translatable-fqn other-domain-test-params-short-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php new \Symfony\Component\Translation\TranslatableMessage('translatable-fqn other-domain-test-params-long-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php new \Symfony\Component\Translation\TranslatableMessage('translatable-fqn typecast', ['a' => (int) '123'], 'not_messages'); ?>
+
+<?php new \Symfony\Component\Translation\TranslatableMessage('translatable-fqn default domain', [], null); ?>

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/translatable-message-visitor/translatable.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-php-ast/translatable-message-visitor/translatable.html.php
@@ -1,0 +1,47 @@
+This template is used for translation message extraction tests
+<?php new TranslatableMessage('translatable single-quoted key'); ?>
+<?php new TranslatableMessage('translatable double-quoted key'); ?>
+<?php new TranslatableMessage(<<<EOF
+translatable heredoc key
+EOF
+); ?>
+<?php new TranslatableMessage(<<<'EOF'
+translatable nowdoc key
+EOF
+); ?>
+<?php new TranslatableMessage(
+    "translatable double-quoted key with whitespace and escaped \$\n\" sequences"
+); ?>
+<?php new TranslatableMessage(
+    'translatable single-quoted key with whitespace and nonescaped \$\n\' sequences'
+); ?>
+<?php new TranslatableMessage(<<<EOF
+translatable heredoc key with whitespace and escaped \$\n sequences
+EOF
+); ?>
+<?php new TranslatableMessage(<<<'EOF'
+translatable nowdoc key with whitespace and nonescaped \$\n sequences
+EOF
+); ?>
+
+<?php new TranslatableMessage('translatable single-quoted key with "quote mark at the end"'); ?>
+
+<?php new TranslatableMessage('translatable concatenated'.' message'.<<<EOF
+ with heredoc
+EOF
+.<<<'EOF'
+ and nowdoc
+EOF
+); ?>
+
+<?php new TranslatableMessage('translatable other-domain-test-no-params-short-array', [], 'not_messages'); ?>
+
+<?php new TranslatableMessage('translatable other-domain-test-no-params-long-array', [], 'not_messages'); ?>
+
+<?php new TranslatableMessage('translatable other-domain-test-params-short-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php new TranslatableMessage('translatable other-domain-test-params-long-array', ['foo' => 'bar'], 'not_messages'); ?>
+
+<?php new TranslatableMessage('translatable typecast', ['a' => (int) '123'], 'not_messages'); ?>
+
+<?php new TranslatableMessage('translatable default domain', [], null); ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Split the existing monolithic PhpAstExtractor test coverage into focused
per-visitor test classes with dedicated test fixtures organized by visitor
type (TransMethodVisitor, TranslatableMessageVisitor, ConstraintVisitor).

Co-Authored-By: Hubert Lenoir <hubert.lenoir@sensiolabs.com>