### PR TITLE
[Security] Add an OIDC Authorization Code Flow authenticator (oidc_login)

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `allowed_time_drift` option to the OIDC token handler configuration
  * Allow disabling the redirection on successful logout by passing `null` to the `target` option
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
+ * Add `oidc_login` firewall authenticator for the OpenID Connect Authorization Code Flow
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * OidcLoginFactory creates services for OpenID Connect Authorization Code Flow authentication.
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ *
+ * @internal
+ */
+class OidcLoginFactory extends AbstractFactory
+{
+    public const int PRIORITY = -25;
+
+    /**
+     * @psalm-suppress ParamNameMismatch
+     */
+    public function addConfiguration(NodeDefinition $node): void
+    {
+        parent::addConfiguration($node);
+
+        \assert($node instanceof ArrayNodeDefinition);
+
+        $node->children()
+            ->scalarNode('provider_uri')
+                ->isRequired()
+                ->cannotBeEmpty()
+                ->validate()
+                    ->ifTrue(static function ($v): bool {
+                        if ('https' === parse_url((string) $v, \PHP_URL_SCHEME)) {
+                            return false;
+                        }
+
+                        return !\in_array(parse_url((string) $v, \PHP_URL_HOST), ['localhost', '127.0.0.1', '::1'], true);
+                    })
+                    ->thenInvalid('The OIDC "provider_uri" must use HTTPS (got %s): the ID token signature is not verified, so transport security is mandatory. Use HTTPS, or a loopback host (localhost, 127.0.0.1) for local development.')
+                ->end()
+                ->info('The OIDC Issuer URL (e.g. "https://accounts.example.com"). Used for .well-known/openid-configuration discovery.')
+            ->end()
+            ->scalarNode('client_id')
+                ->isRequired()
+                ->cannotBeEmpty()
+                ->info('The OIDC client identifier.')
+            ->end()
+            ->scalarNode('client_secret')
+                ->isRequired()
+                ->cannotBeEmpty()
+                ->info('The OIDC client secret.')
+            ->end()
+            ->scalarNode('check_path')
+                ->cannotBeEmpty()
+                ->defaultValue('/oidc/callback')
+                ->info('The firewall path where the OIDC provider redirects after authentication. Must match a redirect URI registered with the provider. A route is registered automatically for this path.')
+            ->end()
+        ;
+    }
+
+    public function getKey(): string
+    {
+        return 'oidc-login';
+    }
+
+    public function getPriority(): int
+    {
+        return self::PRIORITY;
+    }
+
+    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId): string
+    {
+        if (!$container->hasDefinition('security.authenticator.oidc_login')) {
+            $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/../../Resources/config'));
+            $loader->load('security_authenticator_oidc_login.php');
+        }
+
+        $providerUri = rtrim($config['provider_uri'], '/');
+
+        $discoveryId = 'security.authenticator.oidc_login.discovery.'.$firewallName;
+        $container
+            ->setDefinition($discoveryId, new ChildDefinition('security.authenticator.oidc_login.discovery'))
+            ->replaceArgument(2, $providerUri.'/.well-known/openid-configuration')
+            ->replaceArgument(3, $providerUri)
+        ;
+
+        $oidcClientId = 'security.authenticator.oidc_login.client.'.$firewallName;
+        $container
+            ->setDefinition($oidcClientId, new ChildDefinition('security.authenticator.oidc_login.client'))
+            ->replaceArgument(1, new Reference($discoveryId))
+            ->replaceArgument(2, $config['client_id'])
+            ->replaceArgument(3, $config['client_secret'])
+        ;
+
+        $authenticatorId = 'security.authenticator.oidc_login.'.$firewallName;
+        $options = array_intersect_key($config, $this->options);
+        $options['firewall_name'] = $firewallName;
+
+        $container
+            ->setDefinition($authenticatorId, new ChildDefinition('security.authenticator.oidc_login'))
+            ->replaceArgument(1, new Reference($oidcClientId))
+            ->replaceArgument(2, new Reference($discoveryId))
+            ->replaceArgument(3, $config['client_id'])
+            ->replaceArgument(4, new Reference($this->createAuthenticationSuccessHandler($container, $firewallName, $config)))
+            ->replaceArgument(5, new Reference($this->createAuthenticationFailureHandler($container, $firewallName, $config)))
+            ->replaceArgument(6, $options)
+        ;
+
+        $callbackUris = $container->hasParameter('security.oidc_login.callback_uris') ? (array) $container->getParameter('security.oidc_login.callback_uris') : [];
+        $callbackUris[$firewallName] = $config['check_path'];
+        $container->setParameter('security.oidc_login.callback_uris', $callbackUris);
+
+        return $authenticatorId;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/OidcFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/OidcFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * OidcFactory creates services for the OIDC user provider.
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+class OidcFactory implements UserProviderFactoryInterface
+{
+    public function create(ContainerBuilder $container, string $id, array $config): void
+    {
+        $container->setDefinition($id, new ChildDefinition('security.user.provider.oidc'));
+    }
+
+    public function getKey(): string
+    {
+        return 'oidc';
+    }
+
+    public function addConfiguration(NodeDefinition $builder): void
+    {
+        \assert($builder instanceof ArrayNodeDefinition);
+
+        $builder
+            ->beforeNormalization()
+                ->ifTrue(static fn ($v) => null === $v || (\is_array($v) && [] === $v))
+                ->then(static fn () => ['enabled' => true])
+            ->end()
+        ;
+
+        $builder
+            ->children()
+                ->booleanNode('enabled')->defaultTrue()->info('Internal marker; the OIDC provider has no configuration options.')->end()
+            ->end()
+        ;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -43,6 +43,7 @@ use Symfony\Component\Security\Core\User\ChainUserProvider;
 use Symfony\Component\Security\Core\User\InMemoryUserChecker;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\MissingUserProvider;
+use Symfony\Component\Security\Core\User\OidcUserProvider;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Controller\SecurityTokenValueResolver;
@@ -257,6 +258,9 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('security.user.provider.in_memory', InMemoryUserProvider::class)
+            ->abstract()
+
+        ->set('security.user.provider.oidc', OidcUserProvider::class)
             ->abstract()
 
         ->set('security.user.provider.ldap', LdapUserProvider::class)

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\SecurityBundle\Routing\OidcLoginRouteLoader;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcDiscovery;
+use Symfony\Component\Security\Http\Authenticator\OidcLoginAuthenticator;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('security.authenticator.oidc_login', OidcLoginAuthenticator::class)
+            ->abstract()
+            ->args([
+                service('security.http_utils'),
+                abstract_arg('OIDC client'),
+                abstract_arg('OIDC discovery'),
+                abstract_arg('client ID'),
+                abstract_arg('authentication success handler'),
+                abstract_arg('authentication failure handler'),
+                abstract_arg('options'),
+            ])
+
+        ->set('security.authenticator.oidc_login.discovery', OidcDiscovery::class)
+            ->abstract()
+            ->args([
+                service('http_client'),
+                service('cache.app'),
+                abstract_arg('OpenID configuration URL'),
+                abstract_arg('issuer'),
+            ])
+
+        ->set('security.authenticator.oidc_login.client', OidcConfidentialClient::class)
+            ->abstract()
+            ->args([
+                service('http_client'),
+                abstract_arg('OIDC discovery'),
+                abstract_arg('client ID'),
+                abstract_arg('client secret'),
+            ])
+
+        ->set('security.authenticator.oidc_login.route_loader', OidcLoginRouteLoader::class)
+            ->args([
+                '%security.oidc_login.callback_uris%',
+                'security.oidc_login.callback_uris',
+            ])
+            ->tag('routing.route_loader')
+    ;
+};

--- a/src/Symfony/Bundle/SecurityBundle/Routing/OidcLoginRouteLoader.php
+++ b/src/Symfony/Bundle/SecurityBundle/Routing/OidcLoginRouteLoader.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Routing;
+
+use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Registers a route for each oidc_login firewall callback path, so the provider's
+ * redirect lands on a matched route and is handled by the firewall instead of
+ * returning a 404 from the router.
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class OidcLoginRouteLoader
+{
+    /**
+     * @param array<string, string> $callbackUris  Callback URIs indexed by the corresponding firewall name
+     * @param string                $parameterName Name of the container parameter containing {@see $callbackUris} value
+     */
+    public function __construct(
+        private readonly array $callbackUris,
+        private readonly string $parameterName,
+    ) {
+    }
+
+    public function __invoke(): RouteCollection
+    {
+        $collection = new RouteCollection();
+        $collection->addResource(new ContainerParametersResource([$this->parameterName => $this->callbackUris]));
+
+        $routeNames = [];
+        foreach ($this->callbackUris as $firewallName => $callbackPath) {
+            $routeName = '_oidc_login_callback_'.$firewallName;
+
+            if (isset($routeNames[$callbackPath])) {
+                $collection->addAlias($routeName, $routeNames[$callbackPath]);
+            } else {
+                $routeNames[$callbackPath] = $routeName;
+                $collection->add($routeName, new Route($callbackPath));
+            }
+        }
+
+        return $collection;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -38,11 +38,13 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLogin
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLoginLdapFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginLinkFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginThrottlingFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\OidcLoginFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RememberMeFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RemoteUserFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\X509Factory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\InMemoryFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\LdapFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\OidcFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -76,6 +78,7 @@ class SecurityBundle extends Bundle
         $extension->addAuthenticatorFactory(new CustomAuthenticatorFactory());
         $extension->addAuthenticatorFactory(new LoginThrottlingFactory());
         $extension->addAuthenticatorFactory(new LoginLinkFactory());
+        $extension->addAuthenticatorFactory(new OidcLoginFactory());
         $extension->addAuthenticatorFactory(new AccessTokenFactory([
             new ServiceTokenHandlerFactory(),
             new OidcUserInfoTokenHandlerFactory(),
@@ -86,6 +89,7 @@ class SecurityBundle extends Bundle
 
         $extension->addUserProviderFactory(new InMemoryFactory());
         $extension->addUserProviderFactory(new LdapFactory());
+        $extension->addUserProviderFactory(new OidcFactory());
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
         $container->addCompilerPass(new AddSecurityVotersPass());
         $container->addCompilerPass(new AddSessionDomainConstraintPass());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Security\Factory;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\OidcLoginFactory;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class OidcLoginFactoryTest extends TestCase
+{
+    public function testBasicServiceConfiguration()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'check_path' => '/oidc/callback',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login'));
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.main'));
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.discovery.main'));
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.client.main'));
+
+        // the discovery service and the client id are injected directly, not fetched through the OIDC client
+        $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.discovery.main'), $authenticator->getArgument(2));
+        $this->assertSame('my-client-id', $authenticator->getArgument(3));
+    }
+
+    public function testGetKey()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->assertSame('oidc-login', $factory->getKey());
+    }
+
+    public function testGetPriority()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->assertSame(-25, $factory->getPriority());
+    }
+
+    public function testRequiredOptions()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->processConfig([
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+    }
+
+    public function testCheckPathDefaultsToCallback()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+
+        $this->assertSame('/oidc/callback', $finalizedConfig['check_path']);
+    }
+
+    public function testCallbackRouteIsRegistered()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'check_path' => '/oidc/callback',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.route_loader'));
+        $this->assertSame(['main' => '/oidc/callback'], $container->getParameter('security.oidc_login.callback_uris'));
+    }
+
+    public function testRejectsNonHttpsProviderUri()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('must use HTTPS');
+
+        $this->processConfig([
+            'provider_uri' => 'http://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+    }
+
+    public function testAllowsHttpProviderUriForLoopback()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'http://localhost:8080',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+
+        $this->assertSame('http://localhost:8080', $finalizedConfig['provider_uri']);
+    }
+
+    private function processConfig(array $config, OidcLoginFactory $factory): array
+    {
+        $nodeDefinition = new ArrayNodeDefinition('oidc-login');
+        $factory->addConfiguration($nodeDefinition);
+
+        $node = $nodeDefinition->getNode();
+        $normalizedConfig = $node->normalize($config);
+
+        return $node->finalize($normalizedConfig);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/UserProvider/OidcFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/UserProvider/OidcFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Security\UserProvider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\OidcFactory;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class OidcFactoryTest extends TestCase
+{
+    public function testGetKey()
+    {
+        $this->assertSame('oidc', (new OidcFactory())->getKey());
+    }
+
+    public function testCreateRegistersChildOfBuiltinProvider()
+    {
+        $container = new ContainerBuilder();
+
+        (new OidcFactory())->create($container, 'security.user.provider.concrete.oidc_users', []);
+
+        $this->assertTrue($container->hasDefinition('security.user.provider.concrete.oidc_users'));
+        $definition = $container->getDefinition('security.user.provider.concrete.oidc_users');
+        $this->assertInstanceOf(ChildDefinition::class, $definition);
+        $this->assertSame('security.user.provider.oidc', $definition->getParent());
+    }
+
+    public function testAddConfigurationDefaultsEmptyToEnabled()
+    {
+        $factory = new OidcFactory();
+        $treeBuilder = new TreeBuilder('oidc');
+        $factory->addConfiguration($treeBuilder->getRootNode());
+
+        $config = (new Processor())->process($treeBuilder->buildTree(), [null]);
+
+        $this->assertSame(['enabled' => true], $config);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -124,7 +124,7 @@ class SecurityExtensionTest extends TestCase
         ]);
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Unrecognized option "some_other" under "security.providers.my_app_provider". Available options are "chain", "custom", "id", "ldap", "memory".');
+        $this->expectExceptionMessage('Unrecognized option "some_other" under "security.providers.my_app_provider". Available options are "chain", "custom", "id", "ldap", "memory", "oidc".');
 
         $container->compile();
     }

--- a/src/Symfony/Component/Security/Core/Tests/User/OidcUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/OidcUserProviderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\User;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\OidcUser;
+use Symfony\Component\Security\Core\User\OidcUserProvider;
+
+class OidcUserProviderTest extends TestCase
+{
+    public function testLoadUserByIdentifierIsNotSupported()
+    {
+        $provider = new OidcUserProvider();
+
+        $this->expectException(\LogicException::class);
+
+        $provider->loadUserByIdentifier('user-42');
+    }
+
+    public function testRefreshUserReturnsSameUser()
+    {
+        $provider = new OidcUserProvider();
+        $user = new OidcUser(userIdentifier: 'user-42', sub: 'user-42');
+
+        $this->assertSame($user, $provider->refreshUser($user));
+    }
+
+    public function testRefreshUnsupportedUser()
+    {
+        $provider = new OidcUserProvider();
+
+        $this->expectException(UnsupportedUserException::class);
+
+        $provider->refreshUser(new InMemoryUser('john', 'pass'));
+    }
+
+    public function testSupportsClass()
+    {
+        $provider = new OidcUserProvider();
+
+        $this->assertTrue($provider->supportsClass(OidcUser::class));
+        $this->assertFalse($provider->supportsClass(InMemoryUser::class));
+    }
+}

--- a/src/Symfony/Component/Security/Core/User/OidcUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/OidcUserProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\User;
+
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+
+/**
+ * User provider for OIDC users that are created by the OIDC login authenticator.
+ *
+ * This provider supports refreshing OidcUser instances from the session.
+ * Since OIDC users are self-contained (all claims come from the provider),
+ * the user is returned as-is without any external lookup.
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ *
+ * @implements UserProviderInterface<OidcUser>
+ */
+final class OidcUserProvider implements UserProviderInterface
+{
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        throw new \BadMethodCallException(\sprintf('The "%s" provider cannot load a user by its identifier; OIDC users are loaded by the OIDC authenticator.', self::class));
+    }
+
+    public function refreshUser(UserInterface $user): UserInterface
+    {
+        if (!$user instanceof OidcUser) {
+            throw new UnsupportedUserException(\sprintf('Instances of "%s" are not supported.', $user::class));
+        }
+
+        return $user;
+    }
+
+    public function supportsClass(string $class): bool
+    {
+        return OidcUser::class === $class;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcClient.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcClient.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Oidc;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Base HTTP client for OpenID Connect protocol operations.
+ *
+ * Concrete subclasses decide how the client authenticates at the token endpoint
+ * (RFC 6749 §2.3): confidential clients send a secret, public clients rely on PKCE,
+ * other profiles use signed JWTs (OIDC Core §9).
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth OIDC Core 1.0 §3.1
+ * @see https://datatracker.ietf.org/doc/html/rfc6749                      OAuth 2.0 (RFC 6749)
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+abstract class OidcClient
+{
+    public function __construct(
+        protected readonly HttpClientInterface $httpClient,
+        protected readonly OidcDiscovery $discovery,
+        protected readonly string $clientId,
+    ) {
+    }
+
+    /**
+     * Exchanges an authorization code for tokens at the token endpoint.
+     *
+     * @return array<string, mixed>
+     */
+    public function exchangeCode(string $code, string $redirectUri, ?string $codeVerifier = null): array
+    {
+        $config = $this->discovery->getConfiguration();
+
+        $body = [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => $redirectUri,
+            'client_id' => $this->clientId,
+        ];
+
+        if (null !== $codeVerifier) {
+            $body['code_verifier'] = $codeVerifier;
+        }
+
+        $options = $this->applyClientAuthentication($body, []);
+
+        return $this->httpClient->request('POST', $config['token_endpoint'], $options)->toArray();
+    }
+
+    /**
+     * Fetches the user's claims from the OIDC provider's UserInfo endpoint.
+     *
+     * @return array<string, mixed>
+     */
+    public function fetchUserInfo(string $accessToken): array
+    {
+        $config = $this->discovery->getConfiguration();
+
+        if (!isset($config['userinfo_endpoint'])) {
+            throw new \LogicException('The OIDC provider does not expose a userinfo endpoint.');
+        }
+
+        return $this->httpClient->request('GET', $config['userinfo_endpoint'], [
+            'auth_bearer' => $accessToken,
+        ])->toArray();
+    }
+
+    /**
+     * Applies the client authentication scheme to the token endpoint request.
+     *
+     * Subclasses return the final HttpClient options array (typically shaped as
+     * `['body' => ..., 'auth_basic' => ...]`), starting from the given request body.
+     *
+     * @param array<string, mixed> $body    The token request body being built
+     * @param array<string, mixed> $options The HttpClient options being built
+     *
+     * @return array<string, mixed> The final HttpClient options
+     */
+    abstract protected function applyClientAuthentication(array $body, array $options): array;
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcConfidentialClient.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcConfidentialClient.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Oidc;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * OIDC client for confidential clients (holding a client secret).
+ *
+ * Authenticates at the token endpoint using `client_secret_post` (secret in the
+ * request body), per RFC 6749 §2.3.1.
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+class OidcConfidentialClient extends OidcClient
+{
+    public function __construct(
+        HttpClientInterface $httpClient,
+        OidcDiscovery $discovery,
+        string $clientId,
+        private readonly string $clientSecret,
+    ) {
+        parent::__construct($httpClient, $discovery, $clientId);
+    }
+
+    protected function applyClientAuthentication(array $body, array $options): array
+    {
+        $body['client_secret'] = $this->clientSecret;
+        $options['body'] = $body;
+
+        return $options;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcDiscovery.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcDiscovery.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Oidc;
+
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Fetches and caches the OpenID Connect discovery configuration.
+ *
+ * @see https://openid.net/specs/openid-connect-discovery-1_0.html
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+class OidcDiscovery
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly CacheInterface $cache,
+        private readonly string $openIdConfigurationUrl,
+        private readonly string $issuer,
+        private readonly int $cacheTtl = 3600,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed> The raw discovery document
+     */
+    public function getConfiguration(): array
+    {
+        return $this->cache->get('oidc_discovery.'.hash('xxh128', $this->openIdConfigurationUrl), function (ItemInterface $item): array {
+            $item->expiresAfter($this->cacheTtl);
+
+            $configuration = $this->httpClient->request('GET', $this->openIdConfigurationUrl)->toArray();
+
+            // OpenID Connect Discovery 1.0, Section 4.3: the "issuer" returned MUST be
+            // identical to the issuer used to build the discovery URL. Validating it
+            // prevents a tampered discovery document from redefining the expected issuer.
+            if (($configuration['issuer'] ?? null) !== $this->issuer) {
+                throw new \RuntimeException(\sprintf('The OIDC provider announced the issuer "%s", which does not match the configured issuer "%s".', $configuration['issuer'] ?? '', $this->issuer));
+            }
+
+            return $configuration;
+        });
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcIdToken.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcIdToken.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Oidc;
+
+use Jose\Component\Checker\AudienceChecker;
+use Jose\Component\Checker\ClaimCheckerManager;
+use Jose\Component\Checker\ExpirationTimeChecker;
+use Jose\Component\Checker\InvalidClaimException;
+use Jose\Component\Checker\IssuerChecker;
+use Jose\Component\Checker\MissingMandatoryClaimException;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Decodes and validates OIDC ID tokens using the web-token (JOSE) library,
+ * reusing the same claim checkers as the OIDC access-token handlers.
+ *
+ * The signature is not verified: the ID token is received directly from the
+ * token endpoint over TLS, where signature verification MAY be skipped
+ * (OIDC Core 1.0, Section 3.1.3.7, item 6).
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ *
+ * @internal
+ */
+final class OidcIdToken
+{
+    /**
+     * Decodes the claims of a JWT without verifying its signature.
+     *
+     * @return array<string, mixed> The decoded claims
+     *
+     * @throws AuthenticationException If the token cannot be decoded
+     */
+    public static function decode(string $jwt): array
+    {
+        if (!class_exists(JWSSerializerManager::class)) {
+            throw new \LogicException('You cannot decode OIDC ID tokens since the "web-token/jwt-library" package is not installed. Try running "composer require web-token/jwt-library".');
+        }
+
+        try {
+            $payload = (new JWSSerializerManager([new CompactSerializer()]))->unserialize($jwt)->getPayload();
+        } catch (\InvalidArgumentException) {
+            throw new AuthenticationException('Invalid ID token format.');
+        }
+
+        try {
+            $claims = json_decode($payload ?? '', true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            throw new AuthenticationException('Invalid ID token payload.');
+        }
+
+        if (!\is_array($claims)) {
+            throw new AuthenticationException('Invalid ID token payload.');
+        }
+
+        return $claims;
+    }
+
+    /**
+     * Validates ID token claims per OIDC Core 1.0, Section 3.1.3.7.
+     *
+     * @throws AuthenticationException If any claim validation fails
+     */
+    public static function validateClaims(array $claims, string $expectedIssuer, string $expectedAudience, ?string $expectedNonce = null): void
+    {
+        if (!class_exists(ClaimCheckerManager::class)) {
+            throw new \LogicException('You cannot validate OIDC ID tokens since the "web-token/jwt-library" package is not installed. Try running "composer require web-token/jwt-library".');
+        }
+
+        try {
+            (new ClaimCheckerManager([
+                new IssuerChecker([$expectedIssuer]),
+                new AudienceChecker($expectedAudience),
+                new ExpirationTimeChecker(new Clock()),
+            ]))->check($claims, ['iss', 'aud', 'exp']);
+        } catch (InvalidClaimException|MissingMandatoryClaimException $e) {
+            throw new AuthenticationException(\sprintf('Invalid ID token: "%s"', $e->getMessage()), previous: $e);
+        }
+
+        $aud = \is_array($claims['aud']) ? $claims['aud'] : [$claims['aud']];
+        if (\count($aud) > 1 && !isset($claims['azp'])) {
+            throw new AuthenticationException('ID token has multiple audiences but is missing the "azp" claim.');
+        }
+        if (isset($claims['azp']) && !hash_equals($expectedAudience, (string) $claims['azp'])) {
+            throw new AuthenticationException('ID token "azp" claim does not match the expected client_id.');
+        }
+
+        if (null !== $expectedNonce && (!isset($claims['nonce']) || !hash_equals($expectedNonce, (string) $claims['nonce']))) {
+            throw new AuthenticationException('ID token nonce does not match.');
+        }
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
@@ -1,0 +1,253 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\AccessToken\Oidc\OidcTrait;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcClient;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcDiscovery;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\HttpUtils;
+
+/**
+ * Authenticator for the OpenID Connect Authorization Code Flow.
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ *
+ * @final
+ */
+class OidcLoginAuthenticator extends AbstractAuthenticator implements AuthenticationEntryPointInterface, InteractiveAuthenticatorInterface
+{
+    use OidcTrait;
+
+    private array $options;
+
+    public function __construct(
+        private readonly HttpUtils $httpUtils,
+        private readonly OidcClient $oidcClient,
+        private readonly OidcDiscovery $discovery,
+        private readonly string $clientId,
+        private readonly AuthenticationSuccessHandlerInterface $successHandler,
+        private readonly AuthenticationFailureHandlerInterface $failureHandler,
+        array $options,
+    ) {
+        $this->options = array_merge([
+            'check_path' => '/oidc/callback',
+            'firewall_name' => 'main',
+        ], $options);
+    }
+
+    public function supports(Request $request): bool
+    {
+        return $this->httpUtils->checkRequestPath($request, $this->options['check_path'])
+            && ($request->query->has('code') || $request->query->has('error'));
+    }
+
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
+    {
+        $session = $request->getSession();
+        $prefix = $this->getSessionPrefix();
+        $discoveryConfig = $this->discovery->getConfiguration();
+
+        $state = bin2hex(random_bytes(32));
+        $nonce = bin2hex(random_bytes(32));
+        $codeVerifier = $this->generateCodeVerifier();
+
+        $session->set($prefix.'state', $state);
+        $session->set($prefix.'nonce', $nonce);
+        $session->set($prefix.'code_verifier', $codeVerifier);
+
+        $params = [
+            'response_type' => 'code',
+            'client_id' => $this->clientId,
+            'redirect_uri' => $this->httpUtils->generateUri($request, $this->options['check_path']),
+            'scope' => 'openid',
+            'state' => $state,
+            'nonce' => $nonce,
+            'code_challenge' => rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '='),
+            'code_challenge_method' => 'S256',
+        ];
+
+        $authorizationEndpoint = $discoveryConfig['authorization_endpoint'];
+        $authorizationUrl = $authorizationEndpoint
+            .(str_contains($authorizationEndpoint, '?') ? '&' : '?')
+            .http_build_query($params, '', '&', \PHP_QUERY_RFC3986);
+
+        return new RedirectResponse($authorizationUrl);
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $session = $request->getSession();
+        $prefix = $this->getSessionPrefix();
+
+        $this->checkForProviderError($request);
+        $this->validateState($request, $session->get($prefix.'state'));
+
+        $code = $request->query->get('code');
+        if (null === $code) {
+            throw new AuthenticationException('Missing authorization code in OIDC callback.');
+        }
+
+        $storedNonce = $session->get($prefix.'nonce');
+        $tokenData = $this->exchangeAuthorizationCode($request, $session, $code);
+
+        $idTokenClaims = OidcIdToken::decode($tokenData['id_token']);
+        OidcIdToken::validateClaims(
+            $idTokenClaims,
+            $this->discovery->getConfiguration()['issuer'] ?? '',
+            $this->clientId,
+            $storedNonce,
+        );
+
+        $claims = $this->fetchUserClaims($tokenData['access_token'], $idTokenClaims);
+
+        $userLoader = new FallbackUserLoader(function () use ($claims) {
+            $claims['user_identifier'] = $claims['sub'];
+
+            return $this->createUser($claims);
+        });
+
+        $passport = new SelfValidatingPassport(
+            new UserBadge($claims['sub'], $userLoader, $claims),
+        );
+        $passport->setAttribute('oidc_token_data', $tokenData);
+
+        return $passport;
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        $token = new PostAuthenticationToken($passport->getUser(), $firewallName, $passport->getUser()->getRoles());
+
+        $tokenData = $passport->getAttribute('oidc_token_data');
+        if (\is_array($tokenData)) {
+            $token->setAttribute('oidc_id_token', $tokenData['id_token'] ?? null);
+            $token->setAttribute('oidc_access_token', $tokenData['access_token'] ?? null);
+        }
+
+        return $token;
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return $this->successHandler->onAuthenticationSuccess($request, $token);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        return $this->failureHandler->onAuthenticationFailure($request, $exception);
+    }
+
+    public function isInteractive(): bool
+    {
+        return true;
+    }
+
+    private function checkForProviderError(Request $request): void
+    {
+        $error = $request->query->get('error');
+        if (null !== $error) {
+            $description = $request->query->get('error_description', $error);
+            throw new AuthenticationException(\sprintf('OIDC provider returned an error: "%s"', $description));
+        }
+    }
+
+    private function validateState(Request $request, mixed $storedState): void
+    {
+        $state = $request->query->get('state');
+        // reject when no state was stored (empty session) so that an empty/forged
+        // "state" cannot pass an empty === empty comparison (login CSRF)
+        if (!\is_string($storedState) || '' === $storedState || null === $state || !hash_equals($storedState, $state)) {
+            throw new AuthenticationException('Invalid OIDC state parameter.');
+        }
+    }
+
+    /**
+     * Exchanges the authorization code for tokens, clearing the one-time session
+     * values, and ensures the token endpoint returned an ID and access token.
+     *
+     * @return array<string, mixed>
+     */
+    private function exchangeAuthorizationCode(Request $request, SessionInterface $session, string $code): array
+    {
+        $prefix = $this->getSessionPrefix();
+        $codeVerifier = $session->get($prefix.'code_verifier');
+        $redirectUri = $this->httpUtils->generateUri($request, $this->options['check_path']);
+
+        try {
+            $tokenData = $this->oidcClient->exchangeCode($code, $redirectUri, $codeVerifier);
+        } finally {
+            $session->remove($prefix.'state');
+            $session->remove($prefix.'nonce');
+            $session->remove($prefix.'code_verifier');
+        }
+
+        if (!isset($tokenData['id_token'])) {
+            throw new AuthenticationException('The token endpoint response does not contain an "id_token".');
+        }
+        if (!isset($tokenData['access_token'])) {
+            throw new AuthenticationException('The token endpoint response does not contain an "access_token".');
+        }
+
+        return $tokenData;
+    }
+
+    /**
+     * Fetches user claims from the UserInfo endpoint and enforces the OIDC Core
+     * 1.0, Section 5.3.2 rule that its "sub" matches the ID token "sub".
+     *
+     * @param array<string, mixed> $idTokenClaims
+     *
+     * @return array<string, mixed>
+     */
+    private function fetchUserClaims(string $accessToken, array $idTokenClaims): array
+    {
+        $claims = $this->oidcClient->fetchUserInfo($accessToken);
+
+        if (!isset($claims['sub']) || '' === $claims['sub']) {
+            throw new AuthenticationException('The "sub" claim was not found in the OIDC response.');
+        }
+
+        if (!isset($idTokenClaims['sub']) || !hash_equals((string) $idTokenClaims['sub'], (string) $claims['sub'])) {
+            throw new AuthenticationException('The "sub" claim from the UserInfo endpoint does not match the ID token.');
+        }
+
+        return $claims;
+    }
+
+    private function generateCodeVerifier(): string
+    {
+        // A 32-byte (256-bit) verifier, hex-encoded to 64 characters, as recommended
+        // by RFC 7636 Appendix B. The S256 challenge below is the only base64url step.
+        return bin2hex(random_bytes(32));
+    }
+
+    private function getSessionPrefix(): string
+    {
+        return '_security.oidc_login.'.$this->options['firewall_name'].'.';
+    }
+}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add `allowed_time_drift` option to `OidcTokenHandler` to configure time tolerance for token validation (`iat`, `nbf`, `exp` claims)
+ * Add `OidcLoginAuthenticator` for the OpenID Connect Authorization Code Flow (interactive login via OIDC provider)
+ * Add `OidcClient` and `OidcDiscovery` protocol classes
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcConfidentialClientTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcConfidentialClientTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator\Oidc;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcDiscovery;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+#[AllowMockObjectsWithoutExpectations]
+class OidcConfidentialClientTest extends TestCase
+{
+    private OidcDiscovery $discovery;
+    private HttpClientInterface $httpClient;
+
+    protected function setUp(): void
+    {
+        $this->discovery = $this->createMock(OidcDiscovery::class);
+        $this->discovery->method('getConfiguration')->willReturn([
+            'token_endpoint' => 'https://provider.example.com/token',
+            'userinfo_endpoint' => 'https://provider.example.com/userinfo',
+            'issuer' => 'https://provider.example.com',
+        ]);
+
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+    }
+
+    public function testExchangeCodeWithClientSecretPost()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => 'id-token-abc',
+        ]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with('POST', 'https://provider.example.com/token', $this->callback(function (array $options) {
+                $this->assertSame('authorization_code', $options['body']['grant_type']);
+                $this->assertSame('auth-code', $options['body']['code']);
+                $this->assertSame('https://app.example.com/callback', $options['body']['redirect_uri']);
+                $this->assertSame('test-client-id', $options['body']['client_id']);
+                $this->assertSame('test-client-secret', $options['body']['client_secret']);
+                $this->assertArrayNotHasKey('auth_basic', $options);
+
+                return true;
+            }))
+            ->willReturn($response);
+
+        $client = $this->createClient();
+        $tokens = $client->exchangeCode('auth-code', 'https://app.example.com/callback');
+
+        $this->assertSame('access-123', $tokens['access_token']);
+        $this->assertSame('id-token-abc', $tokens['id_token']);
+    }
+
+    public function testExchangeCodeWithCodeVerifier()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => 'id-token-abc',
+        ]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with('POST', 'https://provider.example.com/token', $this->callback(function (array $options) {
+                $this->assertSame('my-code-verifier', $options['body']['code_verifier']);
+
+                return true;
+            }))
+            ->willReturn($response);
+
+        $client = $this->createClient();
+        $client->exchangeCode('auth-code', 'https://app.example.com/callback', 'my-code-verifier');
+    }
+
+    public function testFetchUserInfo()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'sub' => '123',
+            'email' => 'test@example.com',
+        ]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with('GET', 'https://provider.example.com/userinfo', [
+                'auth_bearer' => 'access-token',
+            ])
+            ->willReturn($response);
+
+        $client = $this->createClient();
+        $claims = $client->fetchUserInfo('access-token');
+
+        $this->assertSame('123', $claims['sub']);
+        $this->assertSame('test@example.com', $claims['email']);
+    }
+
+    public function testFetchUserInfoThrowsWhenEndpointMissing()
+    {
+        $discovery = $this->createMock(OidcDiscovery::class);
+        $discovery->method('getConfiguration')->willReturn([
+            'token_endpoint' => 'https://provider.example.com/token',
+        ]);
+
+        $client = new OidcConfidentialClient($this->httpClient, $discovery, 'test-client-id', 'test-client-secret');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('userinfo endpoint');
+
+        $client->fetchUserInfo('access-token');
+    }
+
+    private function createClient(): OidcConfidentialClient
+    {
+        return new OidcConfidentialClient(
+            httpClient: $this->httpClient,
+            discovery: $this->discovery,
+            clientId: 'test-client-id',
+            clientSecret: 'test-client-secret',
+        );
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcDiscoveryTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcDiscoveryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator\Oidc;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcDiscovery;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class OidcDiscoveryTest extends TestCase
+{
+    private const CONFIGURATION = [
+        'issuer' => 'https://provider.example.com',
+        'authorization_endpoint' => 'https://provider.example.com/authorize',
+        'token_endpoint' => 'https://provider.example.com/token',
+    ];
+
+    public function testGetConfigurationFetchesAndDecodesTheDocument()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn(self::CONFIGURATION);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->with('GET', 'https://provider.example.com/.well-known/openid-configuration')
+            ->willReturn($response);
+
+        $discovery = new OidcDiscovery($httpClient, $this->cacheRunningCallback(), 'https://provider.example.com/.well-known/openid-configuration', 'https://provider.example.com');
+
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+    }
+
+    public function testGetConfigurationRejectsIssuerMismatch()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'issuer' => 'https://attacker.example.com',
+            'token_endpoint' => 'https://attacker.example.com/token',
+        ]);
+
+        $httpClient = $this->createStub(HttpClientInterface::class);
+        $httpClient->method('request')->willReturn($response);
+
+        $discovery = new OidcDiscovery($httpClient, $this->cacheRunningCallback(), 'https://provider.example.com/.well-known/openid-configuration', 'https://provider.example.com');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('does not match the configured issuer');
+
+        $discovery->getConfiguration();
+    }
+
+    public function testGetConfigurationServesFromCacheWithoutHttpCall()
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->never())->method('request');
+
+        $cache = $this->createStub(CacheInterface::class);
+        $cache->method('get')->willReturn(self::CONFIGURATION);
+
+        $discovery = new OidcDiscovery($httpClient, $cache, 'https://provider.example.com/.well-known/openid-configuration', 'https://provider.example.com');
+
+        $this->assertSame(self::CONFIGURATION, $discovery->getConfiguration());
+    }
+
+    private function cacheRunningCallback(): CacheInterface
+    {
+        $cache = $this->createStub(CacheInterface::class);
+        $cache->method('get')->willReturnCallback(fn (string $key, callable $callback) => $callback($this->createStub(ItemInterface::class)));
+
+        return $cache;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcIdTokenTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcIdTokenTest.php
@@ -1,0 +1,253 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator\Oidc;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
+
+#[RequiresPhpExtension('openssl')]
+class OidcIdTokenTest extends TestCase
+{
+    public function testDecode()
+    {
+        $jwt = $this->buildJwt(['sub' => 'user-42', 'email' => 'test@example.com']);
+
+        $claims = OidcIdToken::decode($jwt);
+
+        $this->assertSame('user-42', $claims['sub']);
+        $this->assertSame('test@example.com', $claims['email']);
+    }
+
+    public function testDecodeInvalidFormat()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token format');
+
+        OidcIdToken::decode('not-a-jwt');
+    }
+
+    public function testDecodeInvalidBase64()
+    {
+        $this->expectException(AuthenticationException::class);
+
+        OidcIdToken::decode('header.!!!invalid!!!.signature');
+    }
+
+    public function testDecodeInvalidJson()
+    {
+        $header = base64_encode('{"alg":"RS256"}');
+        $payload = rtrim(strtr(base64_encode('not-json'), '+/', '-_'), '=');
+        $signature = base64_encode('sig');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token payload');
+
+        OidcIdToken::decode($header.'.'.$payload.'.'.$signature);
+    }
+
+    public function testValidateClaims()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+            'nonce' => 'expected-nonce',
+        ];
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id', 'expected-nonce');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateClaimsWithArrayAudience()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => ['other-client', 'my-client-id'],
+            'azp' => 'my-client-id',
+            'exp' => time() + 3600,
+        ];
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateClaimsMultipleAudienceMissingAzp()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => ['other-client', 'my-client-id'],
+            'exp' => time() + 3600,
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('azp');
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsWrongAzp()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'azp' => 'another-client',
+            'exp' => time() + 3600,
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('azp');
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsWithoutNonce()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+        ];
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateClaimsWrongIssuer()
+    {
+        $claims = [
+            'iss' => 'https://evil.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsMissingIssuer()
+    {
+        $claims = [
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsWrongAudience()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'wrong-client-id',
+            'exp' => time() + 3600,
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsExpired()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() - 3600,
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsMissingExp()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id');
+    }
+
+    public function testValidateClaimsWrongNonce()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+            'nonce' => 'wrong-nonce',
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('nonce');
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id', 'expected-nonce');
+    }
+
+    public function testValidateClaimsMissingNonceWhenExpected()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('nonce');
+
+        OidcIdToken::validateClaims($claims, 'https://provider.example.com', 'my-client-id', 'expected-nonce');
+    }
+
+    private function buildJwt(array $claims = []): string
+    {
+        return (new CompactSerializer())->serialize(
+            (new JWSBuilder(new AlgorithmManager([new ES256()])))
+                ->create()
+                ->withPayload(json_encode($claims))
+                ->addSignature(self::getJWK(), ['alg' => 'ES256'])
+                ->build()
+        );
+    }
+
+    private static function getJWK(): JWK
+    {
+        // tip: use https://mkjwk.org/ to generate a JWK
+        return new JWK([
+            'kty' => 'EC',
+            'crv' => 'P-256',
+            'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+            'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+            'd' => 'iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220',
+        ]);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
@@ -1,0 +1,425 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcClient;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcDiscovery;
+use Symfony\Component\Security\Http\Authenticator\OidcLoginAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\HttpUtils;
+
+#[AllowMockObjectsWithoutExpectations]
+class OidcLoginAuthenticatorTest extends TestCase
+{
+    private OidcClient $oidcClient;
+    private OidcDiscovery $discovery;
+    private AuthenticationSuccessHandlerInterface $successHandler;
+    private AuthenticationFailureHandlerInterface $failureHandler;
+
+    protected function setUp(): void
+    {
+        $this->discovery = $this->createMock(OidcDiscovery::class);
+        $this->discovery->method('getConfiguration')->willReturn([
+            'authorization_endpoint' => 'https://provider.example.com/authorize',
+            'token_endpoint' => 'https://provider.example.com/token',
+            'issuer' => 'https://provider.example.com',
+            'userinfo_endpoint' => 'https://provider.example.com/userinfo',
+        ]);
+
+        $this->oidcClient = $this->createMock(OidcClient::class);
+
+        $this->successHandler = $this->createStub(AuthenticationSuccessHandlerInterface::class);
+        $this->failureHandler = $this->createStub(AuthenticationFailureHandlerInterface::class);
+    }
+
+    public function testSupportsCallbackWithCode()
+    {
+        $authenticator = $this->createAuthenticator();
+
+        $this->assertTrue($authenticator->supports(Request::create('/oidc/callback?code=abc&state=xyz')));
+    }
+
+    public function testSupportsCallbackWithError()
+    {
+        $authenticator = $this->createAuthenticator();
+
+        $this->assertTrue($authenticator->supports(Request::create('/oidc/callback?error=access_denied')));
+    }
+
+    public function testDoesNotSupportWrongPath()
+    {
+        $authenticator = $this->createAuthenticator();
+
+        $this->assertFalse($authenticator->supports(Request::create('/other-path?code=abc')));
+    }
+
+    public function testDoesNotSupportMissingParams()
+    {
+        $authenticator = $this->createAuthenticator();
+
+        $this->assertFalse($authenticator->supports(Request::create('/oidc/callback')));
+    }
+
+    public function testAuthenticate()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->expects($this->once())
+            ->method('exchangeCode')
+            ->willReturn([
+                'access_token' => 'access-123',
+                'id_token' => $idToken,
+            ]);
+
+        $this->oidcClient->expects($this->once())
+            ->method('fetchUserInfo')
+            ->with('access-123')
+            ->willReturn([
+                'sub' => 'user-42',
+                'email' => 'test@example.com',
+                'name' => 'Test User',
+            ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $passport = $authenticator->authenticate($request);
+
+        $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
+        $this->assertSame('user-42', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+        // no remember-me: it would re-establish a session without contacting the IdP,
+        // and the OIDC user provider cannot reload a user by identifier
+        $this->assertFalse($passport->hasBadge(RememberMeBadge::class));
+        $this->assertSame('access-123', $passport->getAttribute('oidc_token_data')['access_token']);
+    }
+
+    public function testAuthenticateWithInvalidState()
+    {
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest('valid-state', 'nonce');
+        $request->query->set('state', 'wrong-state');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid OIDC state');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRejectsEmptyStateWhenNoneStored()
+    {
+        // login CSRF: an attacker-crafted callback with an empty "state" must not pass
+        // when the victim's session holds no state (empty === empty would otherwise match)
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback?code=attacker-code&state=');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid OIDC state');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateWithProviderError()
+    {
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback?error=access_denied&error_description=User+denied+access');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('User denied access');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateMissingClaim()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['email' => 'test@example.com']);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('"sub" claim');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRejectsUserInfoSubMismatch()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]); // sub => user-42
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn([
+            'sub' => 'someone-else',
+            'email' => 'test@example.com',
+        ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('does not match the ID token');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateMissingAccessToken()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'id_token' => $idToken,
+        ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('access_token');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateClearsSession()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+        $authenticator->authenticate($request);
+
+        $session = $request->getSession();
+        $this->assertNull($session->get('_security.oidc_login.main.state'));
+        $this->assertNull($session->get('_security.oidc_login.main.nonce'));
+        $this->assertNull($session->get('_security.oidc_login.main.code_verifier'));
+    }
+
+    public function testStartRedirectsToProvider()
+    {
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/protected');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $response = $authenticator->start($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $location = $response->getTargetUrl();
+        $this->assertStringStartsWith('https://provider.example.com/authorize?', $location);
+
+        $params = [];
+        parse_str(parse_url($location, \PHP_URL_QUERY), $params);
+        $this->assertSame('code', $params['response_type']);
+        $this->assertSame('test-client-id', $params['client_id']);
+        $this->assertSame('openid', $params['scope']);
+        $this->assertNotEmpty($params['state']);
+        $this->assertNotEmpty($params['nonce']);
+        $this->assertNotEmpty($params['code_challenge']);
+        $this->assertSame('S256', $params['code_challenge_method']);
+    }
+
+    public function testStartStoresStateNonceAndCodeVerifierInSession()
+    {
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/protected');
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $response = $authenticator->start($request);
+        $location = $response->getTargetUrl();
+
+        $params = [];
+        parse_str(parse_url($location, \PHP_URL_QUERY), $params);
+
+        $this->assertSame($params['state'], $session->get('_security.oidc_login.main.state'));
+        $this->assertSame($params['nonce'], $session->get('_security.oidc_login.main.nonce'));
+        $this->assertNotNull($session->get('_security.oidc_login.main.code_verifier'));
+    }
+
+    public function testAuthenticatePassesCodeVerifierToExchangeCode()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->expects($this->once())
+            ->method('exchangeCode')
+            ->with('auth-code', $this->anything(), 'my-verifier')
+            ->willReturn([
+                'access_token' => 'access-123',
+                'id_token' => $idToken,
+            ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce, 'my-verifier');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateMissingIdToken()
+    {
+        $state = bin2hex(random_bytes(16));
+        $nonce = bin2hex(random_bytes(16));
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+        ]);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('id_token');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateMissingAuthorizationCode()
+    {
+        $state = bin2hex(random_bytes(16));
+
+        $authenticator = $this->createAuthenticator();
+        $request = Request::create('/oidc/callback?state='.$state);
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security.oidc_login.main.state', $state);
+        $request->setSession($session);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Missing authorization code');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testCreateTokenStoresOidcTokens()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce);
+        $passport = $authenticator->authenticate($request);
+
+        $token = $authenticator->createToken($passport, 'main');
+
+        $this->assertSame($idToken, $token->getAttribute('oidc_id_token'));
+        $this->assertSame('access-123', $token->getAttribute('oidc_access_token'));
+    }
+
+    public function testSessionClearedEvenWhenExchangeCodeFails()
+    {
+        $state = bin2hex(random_bytes(16));
+        $nonce = bin2hex(random_bytes(16));
+
+        $this->oidcClient->method('exchangeCode')->willThrowException(new \RuntimeException('Token exchange failed'));
+
+        $authenticator = $this->createAuthenticator();
+        $request = $this->createCallbackRequest($state, $nonce, 'verifier');
+
+        try {
+            $authenticator->authenticate($request);
+        } catch (\RuntimeException) {
+        }
+
+        $session = $request->getSession();
+        $this->assertNull($session->get('_security.oidc_login.main.state'));
+        $this->assertNull($session->get('_security.oidc_login.main.nonce'));
+        $this->assertNull($session->get('_security.oidc_login.main.code_verifier'));
+    }
+
+    private function createCallbackRequest(string $state, string $nonce, ?string $codeVerifier = null): Request
+    {
+        $request = Request::create('/oidc/callback?code=auth-code&state='.$state);
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $prefix = '_security.oidc_login.main.';
+        $session->set($prefix.'state', $state);
+        $session->set($prefix.'nonce', $nonce);
+        if (null !== $codeVerifier) {
+            $session->set($prefix.'code_verifier', $codeVerifier);
+        }
+
+        return $request;
+    }
+
+    private function buildIdToken(array $extraClaims = []): string
+    {
+        $header = rtrim(strtr(base64_encode(json_encode(['alg' => 'RS256', 'typ' => 'JWT'])), '+/', '-_'), '=');
+        $claims = array_merge([
+            'iss' => 'https://provider.example.com',
+            'aud' => 'test-client-id',
+            'sub' => 'user-42',
+            'exp' => time() + 3600,
+            'iat' => time(),
+        ], $extraClaims);
+        $payload = rtrim(strtr(base64_encode(json_encode($claims)), '+/', '-_'), '=');
+        $signature = rtrim(strtr(base64_encode('fake-signature'), '+/', '-_'), '=');
+
+        return $header.'.'.$payload.'.'.$signature;
+    }
+
+    private function createAuthenticator(array $options = []): OidcLoginAuthenticator
+    {
+        return new OidcLoginAuthenticator(
+            new HttpUtils(),
+            $this->oidcClient,
+            $this->discovery,
+            'test-client-id',
+            $this->successHandler,
+            $this->failureHandler,
+            $options,
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | —
| License       | MIT

## TL;DR

This PR adds OIDC Authorization Code Flow natively to Symfony. This is the 1st PR of a series that aims to cover a large set (close to "all") of options described across various RFCs.

### Common use case: 

```mermaid
sequenceDiagram
    participant User
    participant App as Service Provider <br> (Symfony App)
    participant IdP as Identity Provider <br> (OIDC Provider)

    User->>App: Access protected resource
    App->>IdP: OIDC Authorization Request
    IdP->>User: Redirects to the login page
    User->>IdP: Enter credentials
    IdP->>IdP: Validate credentials
    IdP->>IdP: Generate ID token + Access token
    IdP-->>App: Redirection with <br> Authorization code in query string
    App->>IdP: Exchange code for tokens
    IdP-->>App: ID token + Access token
    rect rgba(201, 150, 255, 0.55)
    App->>App: Validate the ID token <br> (signature & expiration)
    end
    rect rgba(150, 201, 255, 0.48)
    App->>App: Extract user claims & roles
    App->>App: Create Passport with tokens in a badge
    App->>App: Do the authentication process
    end
    rect rgba(150, 255, 201, 0.49)
    App->>App: Create Security Token object <br> with ID token and Access token in it
    end
    App-->>User: Redirect to protected resource
```

## OIDC in Symfony today

Symfony already supports OpenID Connect for **stateless, resource-server authentication** — the API/machine-to-machine case where the client already holds a token. The `access_token` authenticator, together with the OIDC token handlers, validates a Bearer token from the request and maps it to a user:

- **`OidcTokenHandler`** — validates a signed (JWS, optionally encrypted JWE) ID/access token locally against the provider's keys, using the `web-token` (JOSE) library and its claim checkers;
- **`OidcUserInfoTokenHandler`** — resolves the user by calling the provider's UserInfo endpoint.

Both build an `OidcUser` from the resulting claims (via `OidcTrait`).

## What's missing today

There is no built-in support for the **interactive end-user login flow** — the "Log in with…" experience that web applications actually need:

> a user opens a protected page → is redirected to the Identity Provider → authenticates there → is redirected back, and the application opens a session.

This is the OIDC **Authorization Code Flow**. The existing token handlers don't cover it: they validate a token the client already obtained, they don't drive the browser redirect → callback → code-exchange sequence or establish the session. Today this gap is filled by third-party bundles (e.g. [drenso/symfony-oidc](https://github.com/Drenso/symfony-oidc)).

## What this PR adds

A first-class `oidc_login` firewall authenticator that implements the Authorization Code Flow:

```yaml
security:
    firewalls:
        main:
            oidc_login:
                provider_uri:  '%env(OIDC_PROVIDER_URI)%'
                client_id:     '%env(OIDC_CLIENT_ID)%'
                client_secret: '%env(OIDC_CLIENT_SECRET)%'
                check_path:    /oidc/callback
```

**The flow and the classes that implement it:**

- **`OidcLoginAuthenticator`** — the entry point redirects to the provider's authorization endpoint (`response_type=code`, `openid` scope, `state`, `nonce`, S256 PKCE). On the callback it validates `state`, exchanges the authorization code for tokens, validates the ID token, fetches the user's claims, and lets the firewall open the session.
- **`OidcClient` / `OidcConfidentialClient`** — token-endpoint exchange and UserInfo retrieval (`client_secret_post`).
- **`OidcDiscovery`** — resolves the authorization, token and userinfo endpoints (and the issuer) from `.well-known/openid-configuration`, so no manual endpoint wiring is needed.
- **`OidcIdToken`** — ID-token claim validation that **reuses the same `web-token` JOSE claim checkers as the existing token handlers** (`iss` / `aud` / `exp`), plus the OIDC-specific `nonce` and `azp` rules.
- **`OidcUserProvider`** and the `oidc` user provider.
- **`OidcLoginFactory`** — registers and wires the `oidc_login` firewall key.

It **reuses the existing `OidcUser` and `OidcTrait`** — no new user model is introduced.

**Secure by default:**

- `state` (CSRF) and `nonce` (replay) are generated, session-bound, and validated;
- PKCE with S256 is enabled (RFC 9700 §2.1.1);
- ID-token claims are validated (OIDC Core 1.0 §3.1.3.7), and the UserInfo `sub` must match the ID token (§5.3.2);
- signature verification is intentionally skipped because the ID token is fetched directly from the token endpoint over TLS, where it is allowed (OIDC Core 1.0 §3.1.3.7 item 6).

**Specifications:** OIDC Core 1.0 §3.1, OIDC Discovery 1.0, [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749), [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636) (PKCE), [RFC 9700](https://datatracker.ietf.org/doc/html/rfc9700).

## Tested with

- [Keycloak](https://github.com/keycloak/keycloak) ✅ 
- [Authelia](https://github.com/authelia/authelia) ✅ 
- [Microsoft Entra ID](https://learn.microsoft.com/fr-fr/entra/identity/) ✅ 
- [Gravitee](https://documentation.gravitee.io/am) ✅

## Following PRs

Next items are related to existing branches on my own fork, split from this one to avoid gigantic PR to review.

- **PKCE (Proof Key for Code Exchange) configuration & pluggable methods**: make PKCE toggleable and its challenge method configurable, with pluggable `PkceMethodInterface` implementations (built-in `S256` and `plain`).
- **Authorization-request customization**: add `prompt`, `max_age` (also enforced against the ID-token `auth_time`), and a free-form bag for any extra authorization-request parameter.
- **Claims source & user-identifier mapping**: allow sourcing claims from UserInfo or the ID token, map the user identifier to any claim, and enforce the UserInfo/ID-token `sub` match (OIDC §5.3.2).
- **Token-endpoint client authentication**: support both `client_secret_post` and `client_secret_basic` at the token endpoint.
- **RP-Initiated Logout**: redirect to the provider's `end_session_endpoint` on logout, falling back to a local logout when it's not advertised.
- **Entry-point & discovery tuning**: optionally redirect straight to the provider instead of a custom login path, and make the discovery document cache TTL configurable.

## Future steps

Larger items to keep in mind (from @Spomky review feedback):

- **Multiple providers per firewall**: let a single firewall offer several OIDC providers at once, instead of today's one-provider-per-firewall. Needs a provider-keyed config, per-provider discovery/client and session namespacing, callback disambiguation (per-provider `check_path` or the provider encoded in `state`), and a provider-aware entry point.
- **Configurable `response_type` (hybrid flows)**: support `id_token`, `code id_token`, `code token`, etc., so the authenticator can already hold an ID token and/or access token and skip an extra call to the provider. Because the ID token then arrives via the front channel, this comes with JWKS-based ID-token signature verification.
- **`response_mode=form_post`**: return the authorization response as a POST body instead of query parameters, to avoid leaking code/token into logs and browser history.
- **Request Objects**: pass authorization parameters as a signed request object (by value or via `request_uri`), preventing tampering and leaks; the `request_uri` variant requires exposing an extra endpoint.
- **`session_state` handling**: track `session_state` so session-based and provider-initiated logout can be handled correctly.
- **Dynamic client registration (RFC 7591)**: build on the existing generic/confidential `OidcClient` split to register clients with the provider dynamically.
